### PR TITLE
feat: parser processes definition in batches 

### DIFF
--- a/\
+++ b/\
@@ -6,17 +6,19 @@ import (
 
 func ParseDefinition(raw string, depth int) string {
 	tokenizer := NewTokenizer(raw)
+
 	definition := ""
 
-	// While loop, while def length is less than sentence depth, keep batching
+	// While loop, while def length is less than sentence depth, keep processing
+	// batches
 	batch := 1
 	batchSize := 100
 	for !isDefinitionParsed(&definition, &tokenizer, depth) {
 		tokenizer.Tokenize(TokenizerOptions{batch, batchSize})
 		definition = ""
 
-		// FIXME: we're doing a little extra work by resetting the definition above
-		// and processing tokens over again. Perhaps an unapply last token func?
+		// Need to track index of token we're currently looking at to continue
+		// parsing definition
 		for _, t := range tokenizer.tokens {
 			switch t.Type {
 			case "text":


### PR DESCRIPTION
Leads to a significant improvement in definition parsing since we're not tokenizing the entire page for every definition.

Before
------
goos: darwin
goarch: arm64
pkg: github.com/runik-3/builder/internal/wikitext
cpu: Apple M1
BenchmarkParsing-8           100           5577068 ns/op
BenchmarkParsing-8           100           5354698 ns/op
BenchmarkParsing-8           100           5357591 ns/op
BenchmarkParsing-8           100           5339744 ns/op
BenchmarkParsing-8           100           5347584 ns/op
PASS
ok      github.com/runik-3/builder/internal/wikitext    2.923s

After
-----
goos: darwin
goarch: arm64
pkg: github.com/runik-3/builder/internal/wikitext
cpu: Apple M1
BenchmarkParsing-8           100           2064198 ns/op
BenchmarkParsing-8           100           1689814 ns/op
BenchmarkParsing-8           100           1678647 ns/op
BenchmarkParsing-8           100           1678310 ns/op
BenchmarkParsing-8           100           1671375 ns/op
PASS
ok      github.com/runik-3/builder/internal/wikitext    1.075s