### PR TITLE
perf: tokenizer and parser performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 # Test binary, built with `go test -c`
 *.test
 
+# pprof profiling files
+*.prof

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ test:
 
 .PHONY: bench
 bench: 
-	@go test ./... -bench=. -benchtime=100x -count=5 -run=^#
+	@go test ./... -bench=. -benchtime=50x -count=5 -run=^#
 
 .PHONY: bench-parser
 bench-parser: 
-	@go test ./... -bench=BenchmarkParsing -benchtime=100x -count=5 -run=^#
+	@go test ./... -bench=BenchmarkParsing -benchtime=50x -count=5 -run=^#
 
 .PHONY: bench-tokenizer
 bench-tokenizer: 
-	@go test ./... -bench=BenchmarkTokenizer -benchtime=100x -count=5 -run=^#
+	@go test ./... -bench=BenchmarkTokenizer -benchtime=50x -count=5 -run=^#

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ Ingrid is the star that fell 400 years before Yvaine did, more precisely at some
 
 A snippet of the resulting dictfile.
 
+### Run with cpu profiling
+
+Use the `cpuprofile` flag to generate an output file containing pprof profiling data.
+
+```
+builder -o ./ -f df -cpuprofile cpu.prof generate https://stardust.fandom.com/api.php
+```
+
+View in pprof.
+
+```sh
+go tool pprof cpu.prof
+# Or web view
+go tool pprof -http=:8080 cpu.prof
+```
+
 ## Module use
 
 Builder can be imported as a module to use in your own projects. Run the following command in the root of your project to add builder.

--- a/internal/testUtils/test.go
+++ b/internal/testUtils/test.go
@@ -1,12 +1,23 @@
 package testUtils
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
 
 func IsEqual(t *testing.T, val1 any, val2 any, message string) {
 	if val1 != val2 {
+		if message != "" {
+			t.Fatal(message)
+		} else {
+			t.Fatalf("%v not equal to %v", val1, val2)
+		}
+	}
+}
+
+func BytesEqual(t *testing.T, val1 byte, val2 byte, message string) {
+	if !bytes.Equal([]byte{val1}, []byte{val2}) {
 		if message != "" {
 			t.Fatal(message)
 		} else {

--- a/internal/wikitext/fixtures/test_wikitext_lg_1.txt
+++ b/internal/wikitext/fixtures/test_wikitext_lg_1.txt
@@ -1,7 +1,3 @@
-This test content comes from https://kingkiller.fandom.com/wiki/Kvothe
-
-= ...... =
-
 {{quote|I have stolen princesses back from sleeping barrow kings. I burned down the town of Trebon. I have spent the night with Felurian and left with both my sanity and my life. I was expelled from the University at a younger age than most people are allowed in. I tread paths by moonlight that others fear to speak of during day. I have talked to Gods, loved women, and written songs that make the minstrels weep. You may have heard of me.|Kote{{ref|TNOTW}}}}
 {{Character
 |image = The kingkiller chronicle kvothe by shilesque-d8m6yzz.jpg

--- a/internal/wikitext/fixtures/test_wikitext_lg_2.txt
+++ b/internal/wikitext/fixtures/test_wikitext_lg_2.txt
@@ -1,0 +1,273 @@
+{{Featured star}}
+{{Disamb-two|member of [[Thorin and Company|Thorin's Company]]|king of Durin's Folk|[[Glóin (King of Durin's Folk)|Glóin]]}}
+{{Infobox Person Dwarves
+| image = Gloin_2.jpg|Glóin in The Hobbit films.
+| caption = Glóin, as portrayed by Peter Hambleton
+| name = Glóin
+| othernames =
+| title =
+| birth = [[TA 2783]]
+| rule =
+| death = [[FO 15]]
+| realms =
+| spouse = Unnamed wife
+| weapon = Axe
+| race = [[Dwarves]]
+| culture = [[Durin's Folk]], Dwarves of the [[Lonely Mountain]]
+| gender =Male 
+| height =About 4'0" at least
+| hair = White
+| eyes = 
+| actor = [[Peter Hambleton]]<br>
+[[John Rhys-Davies]]
+| voice = Jack DeLeon (in 1997 film ''The Hobbit'')<br>[[Steve Blum]] ([[The Lord of the Rings: The Battle for Middle-earth II: The Rise of the Witch-king|video game]])
+| character =
+|children =[[Gimli]] |age =253 (at death) |siblings = |parentage = }}
+
+'''Glóin''', son of [[Gróin]] was one of the [[Dwarves]] of [[Thorin II Oakenshield]]'s company who set out to reclaim the [[Lonely Mountain]] in the [[Quest of Erebor]]''[[The Hobbit|.]]'' He was also the father of [[Gimli]], who became a member of the [[The Fellowship of the Ring (group)|Fellowship of the Ring]].
+
+Glóin chiefly appears in ''[[The Hobbit]]'' as a supporting character. Glóin also appears in [[The Fellowship of the Ring (novel)|''The Fellowship of the Ring'']]'' ''during the [[Council of Elrond]].
+
+== Biography ==
+=== Early life ===
+Glóin was born in [[TA 2783]], after the [[Dragons|dragon]] [[Smaug]] desolated Erebor. He was the younger child of Gróin and younger brother of [[Óin]].
+
+In [[TA 2799]], Glóin was known to have fought in the [[Battle of Azanulbizar]], the last battle of the [[War of the Dwarves and Orcs]], though it is unknown how significant his contribution was, being 16 years old.
+
+In [[TA 2879]], in the [[Blue Mountains]], while in exile, his son Gimli was born to him and an unknown wife. In March of [[TA 2941]] in [[Bree]], Thorin Oakenshield met by chance the [[Wizards|wizard]] [[Gandalf|Gandalf the Grey]], pushing Thorin to reclaim Erebor, so that Smaug wouldn't ally with [[Sauron]]. When Gandalf mentioned [[Hobbits]], Glóin referred them as "simpletons" and also said that Hobbits "would never dare to come within smelling distance of the nakedest dragonet new from the shell". 
+
+=== Quest for Erebor ===
+In [[TA 2941]], Glóin and his brother Óin, along with his cousins [[Dwalin]] and [[Balin]], were among the Dwarves accompanying [[Thorin and Company]] during their quest to the [[Lonely Mountain]] to recapture it from the dragon Smaug. He was noted for his skills with a tinderbox, and, along with his brother Óin, was usually the one told to get a fire started whenever the Dwarves made camp. Glóin also fought in the [[Battle of Five Armies]].<ref>''[[The Hobbit]]''</ref> After the battle, he made his home in the Lonely Mountain.
+
+=== War of the Ring ===
+
+On [[October 25]], [[TA 3018|3018]], Glóin and his son [[Gimli]] attended the [[Council of Elrond]] in [[Rivendell]], where he greeted [[Frodo Baggins]] at the welcome dinner, after Frodo had recovered from his wound received from the [[Witch-king of Angmar]]. He recounted the history of the Lonely Mountain and the Kingdom of [[Dale]] since [[Bilbo Baggins|Bilbo]] had left, including Balin's decision to leave the Lonely Mountain and re-establish the ancient Dwarven kingdom in [[Khazad-dûm|Moria]]. At the Council of Elrond, his son Gimli warned of the messengers from [[Mordor]] who had been threatening King [[Dáin II Ironfoot]], seeking news of Bilbo, Frodo, and the [[One Ring]]. It is unknown whether Glóin fought against [[Sauron]]'s forces in the [[Battle of Dale]].
+
+=== Later life ===
+Glóin died in [[FO 15]] at the age of 253.<ref>{{LotRlink}}, [[Appendix A]]: ''Annals of the Kings and Rulers,'' III: "Durin's Folk"</ref>
+
+{{House of Farin}}
+
+== In adaptations ==
+
+=== ''The Hobbit'' film (1977) ===
+[[File:Rankin Bass Gloin.PNG|thumb|Gloin (1977)]]
+In the animated version of ''The Hobbit'', Glóin is shown near his brother, Óin. He fought in the Battle of Five Armies, and stood by Thorin's side;  he is voiced by [[wikipedia:Jack DeLeon|Jack DeLeon]].
+
+=== The ''Lord of the Rings'' film trilogy ===
+
+Glóin briefly appears in ''[[The Lord of the Rings: The Fellowship of the Ring]]'' as he and Gimli enter Rivendell; played in fact by [[John Rhys-Davies]], who also played Gimli.
+
+=== ''The Hobbit'' film trilogy ===
+
+In ''[[The Hobbit: An Unexpected Journey]]'', Glóin is portrayed by [[Peter Hambleton]]. Glóin is seen wielding axes that look identical to those carried by his son Gimli in Peter Jackson's [[The Lord of the Rings film trilogy|''The Lord of the Rings'' films]].
+
+In ''[[The Hobbit: The Desolation of Smaug]]'', Glóin is captured by [[Mirkwood]]'s Elvenguards right after encountering the [[spiders]]. [[Legolas]] confiscates and speaks insultingly about portraits of Glóin's wife and his young son Gimli. Later, the rest of the Company pressure Glóin to contribute his remaining money to help pay for having [[Bard]] smuggle them into [[Lake-town]]. He gives in when he sees how close they are to the Lonely Mountain.
+
+=== Radio series ===
+
+In the 1968 radio series ''The Hobbit'', he was voiced by Peter Baldwin.
+
+=== Video games ===
+*Along with the rest of Thorin's Company, Glóin appears in ''[[The Hobbit (2003 video game)|The Hobbit]]'' [[The Hobbit (2003 video game)|(2003 video game)]].
+
+*In ''[[The Lord of the Rings: The Battle for Middle-earth II]]'', he and [[Glorfindel]] are leading a campaign in the north following the Fellowship's departure. 
+*In [[The Lord of the Rings Online|''The Lord of the Rings Online'']] Glóin and other Dwarves make a camp in the [[Misty Mountains]] above Rivendell and combat the threats found in the mountains, such as goblins and [[Wargs]], determined to make passage between Rivendell and the Lonely Mountain safe once more.
+
+[[File:Glóin - LOTRO.jpg|thumb|Glóin in ''The Lord of the Rings Online'']]
+* Glóin's first chronological appearance is a cameo in a brief scene showing the departure of [[Thorin II Oakenshield|Thorin Oakenshield]]'s company from the [[Blue Mountains|Ered Luin]]. He then appears in the [[Misty Mountains]] north of [[Rivendell]], where in late 3017 T.A. Glóin and a few other Dwarves establish a camp to deal with the treats in the [[High Pass]] and the [[Goblin-town]]. He eventually returns to the [[Lonely Mountain]] and in 3018 T.A. after the [[Battle of Dale]] Glóin reunites with the other surviving members of Thorin's Company. Later that year [[Nori]] takes some on an expedition to [[Ered Mithrin (north)|Ered Mithrin]] against the orders of King [[Thorin III Stonehelm|Thorin III]] and Glóin and [[Bofur]] join [[Dori]] on a mission to rescue his brother from his own folly. The Dwarves travel through the Grey Mountains and eventually find Nori, but unlike the other Glóin does not immediately return to Erebor. Instead, he stays in the Grey Mountains where he becomes involved in Prince [[Durin VII|Durin]]'s upcoming war against the [[Orcs]] of [[Mount Gundabad|Gundabad]]. On Durin's orders Glóin and some other Dwarves track down a raiding party from Gundabad through the wellsprings of [[Anduin]], eventually travelling to the northernmost outposts of the [[Beornings]].
+
+=== Voice dubbing actors ===
+
+<div style="overflow:auto; height:300px; width:500px; float:left">
+
+<!--<div style="overflow:auto; height:200px;">-->
+{| class="itemtable" style="color:#6f3d0b; border:2px solid #FFF; border-top: 0; text-align:left; -moz-border-radius-bottomleft:8px; -moz-border-radius-bottomright:8px; -webkit-border-bottom-left-radius:8px; -webkit-border-bottom-right-radius:8px;" bgcolor="#edeeff"
+| width="300" |'''Foreign Language'''
+| width="300" |'''Voice dubbing artist'''
+|-
+|Spanish (Latin America)
+|Rubén Trujillo
+|-
+|Spanish (Spain)
+|Joaquín Gómez
+|-
+|Portuguese (Brazil) (Television/DVD)
+|Mauro Ramos
+|-
+|Italian (Italy)
+|Claudio Fattoretto ''(AUJ)'' / Edoardo Siravo ''(DOS)''
+|-
+|German
+|Uli Krohm
+|-
+|French (France)
+|Jean-Claude Sachot
+|-
+|Czech Republic
+|Tomáš Borůvka
+|-
+|Slovak
+|Karol Čálik
+|-
+|Hungarian
+|Ákos Kőszegi
+|-
+|Polish
+|Leon Charewicz
+|}
+</div>
+
+{{Clear}}
+
+== Gallery ==
+{{Gallery|width=120|height=160|captionalign=center|position=center
+|Gloin_2.jpg|Glóin in The Hobbit films
+|Gloin.jpg|Glóin at the Council of Elrond
+|gloin's axe.png|Glóin's battle axe (and Gimli’s)
+|Gloin_THrow.jpg|Close-up of Glóin's hand axe in his belt
+|gloinfigure.jpg|Figurine of Glóin manufactured by Games Workshop
+|H-1-0244-gloin-oin.jpg|Glóin (left) in the 1977 animated version of "The Hobbit"
+|LEGO_Gloin.jpg|Glóin in LEGO The Hobbit
+|Screen Shot 2013-03-03 at 11.01.28 AM.png|LEGO Old Glóin, as he appears in [[LEGO The Lord of the Rings: The Video Game]]
+|GloinPoster.jpeg|Gloín seen on a poster for ''An Unexpected Journey''
+|Gloin (Leadship).JPG|Gloín in ''[[Lord of the Rings: The Card Game]]''|Gloin (Ally).JPG|Gloín in ''[[The Lord of the Rings: The Card Game]], The Hobbit: On the Doorstep Expansion''}}
+
+==Translations==
+<!--<div style="overflow:auto; height:200px;">-->
+{|class="mw-collapsible mw-collapsed" data-expandtext="Show" data-collapsetext="Hide" style="border: 1px solid #a6a6a6; width:65%;"
+| width="300" |'''Foreign Language'''
+| width="300" |'''Translated name'''
+|-
+|Amharic
+|ግሎኢን
+|-
+|Arabic
+|علوين
+|-
+|Armenian
+|Գլոին
+|-
+|Belarusian Cyrillic
+|Глоін
+|-
+|Bengali
+|গ্লোইং
+|-
+|Bulgarian Cyrillic
+|Глоин
+|-
+|Chinese (Hong Kong)
+|葛羅音
+|-
+|Georgian
+|გლოინი
+|-
+|Greek
+|Γλοιν
+|-
+|Gujarati
+|ગ્લોઇન
+|-
+|Hebrew
+|גלואין
+|-
+|Hindi
+|ग्लोइन
+|-
+|Japanese
+|グローイン
+|-
+|Kazakh
+|Глоін (Cyrillic) Gloin (Latin)
+|-
+|Kannada
+|ಗ್ಲೋಯಿನ್
+|-
+|Korean
+|글로빈
+|-
+|Kyrgyz Cyrillic
+|Глоин
+|-
+|Macedonian Cyrillic
+|Глоин
+|-
+|Marathi
+|ग्लिसन
+|-
+|Mongolian Cyrillic
+|Глоин
+|-
+|Nepalese
+|ग्लोइन
+|-
+|Pashto
+|علوین ?
+|-
+|Persian
+|گلوین
+|-
+|Punjabi
+|ਗ੍ਲੋਇਨ
+|-
+|Russian
+|Глоин
+|-
+|Sanskrit
+|ङ्लोइन्
+|-
+|Serbian
+|Глоинов (Cyrillic) Gloinov (Latin)
+|-
+|Sinhalese
+|ග්ලොඉන්
+|-
+|Tajik Cyrillic
+|Глоин
+|-
+|Tamil
+|குளோரின்
+|-
+|Telugu
+|గ్లోయిం
+|-
+|Ukrainian Cyrillic
+|Ґлоїн
+|-
+|Urdu
+|گلاوان
+|-
+|Uzbek
+|Глоин (Cyrillic) Gloin (Latin)
+|-
+|Yiddish
+|גלאָין
+|}
+
+{{Clear}}
+{{Thorin and Company}}
+
+== References ==
+<references />
+[[de:Glóin (Sohn von Gróin)]]
+[[es:Glóin]]
+[[fr:Glóin]]
+[[it:Glóin]]
+[[nl:Glóin]]
+[[pl:Glóin]]
+[[pt-br:Glóin]]
+[[ru:Глоин]]
+[[sk:Glóin]]
+[[uk:Ґлоїн]]
+
+
+[[Category:Dwarves]]
+[[Category:Thorin and Company]]
+[[Category:The Hobbit characters]]
+[[Category:Minor characters (The Lord of the Rings)]]
+[[Category:The Fellowship of the Ring (film) characters]]
+[[Category:The Hobbit: An Unexpected Journey characters]]
+[[Category:The Hobbit: The Desolation of Smaug characters]]
+[[Category:The Hobbit: The Battle of the Five Armies characters]]
+[[Category:Characters that have appeared in the Hobbit and the Lord of the Rings]]

--- a/internal/wikitext/fixtures/test_wikitext_lg_3.txt
+++ b/internal/wikitext/fixtures/test_wikitext_lg_3.txt
@@ -1,0 +1,182 @@
+[[File:Red Keep at Kings Landing, Ted Nasmith.jpg|thumb|The Red Keep over [[King's Landing]], by Ted Nasmith ©]]
+The '''Red Keep''' is a castle on [[Aegon's Hill]] in [[King's Landing]], the capital of the [[Seven Kingdoms]]. The Red Keep contains the [[Iron Throne]] and is the home of King [[Robert I Baratheon]], [[Lord of the Seven Kingdoms]].
+
+==Layout==
+{{See also|:Category:Images of the Red Keep|l1=Images of the Red Keep}}
+[[File:The iron throne.jpg|thumb|The [[Iron Throne]] in the throne room, by Marc Simonetti © Penguin Random House Grupo Editorial]]
+The Red Keep is made of pale red stone{{Ref|AGOT|18}} and overlooks the mouth of the [[Blackwater Rush]].{{Ref|ACOK|58}} The Red Keep has seven massive drum-towers crowned with iron ramparts.{{Ref|AGOT|18}} The castle is smaller than [[Winterfell]]{{Ref|AGOT|32}} and is patrolled by gold cloaks.{{Ref|AGOT|47}} Much of the Red Keep is connected underground.{{Ref|ASOS|58}}
+
+Massive curtain walls surround the castle, with nests and crenelations for archers.{{Ref|AGoT|18}} Thick stone parapets, some four feet high, protect the outer edge of the wall ramparts, where the heads of traitors are traditionally placed on iron spikes between the crenels at the gatehouse.{{Ref|AGOT|67}} The walls have great [[bronze]] gates{{Ref|AGOT|20}} and portcullises, with narrow postern doors nearby.{{Ref|AGOT|18}} The castle also has great cornerforts.{{Ref|ACOK|52}} The immense barbican has a cobbled square in front of it.{{Ref|ACOK|41}} Behind the walls are small inner yards, vaulted halls, covered bridges, barracks of the [[City Watch of King's Landing]], dungeons, granaries, kennels, and stables.{{Ref|AGOT|18}}{{Ref|AGOT|32}}{{Ref|ASOS|12}}{{Ref|ASOS|54}}
+
+The Red Keep has serpentine steps which can be strenuous to climb.{{Ref|ACOK|18}} [[Maegor's Holdfast]],{{Ref|ACOK|18}} the [[small council]] chambers,{{Ref|ACOK|15}} the [[Tower of the Hand]],{{Ref|ACOK|15}} the lower bailey,{{Ref|ACOK|17}} a small sunken courtyard,{{Ref|ASOS|61}} and the [[black cells]]{{Ref|ASOS|70}} are located below the steps. The [[Great Hall (Red Keep)|Great Hall]] with the throne room is found above the steps,{{Ref|AFFC|24}} and the outer yard or ward is found near the main gate.{{Ref|ACOK|17}}{{Ref|ASOS|4}}{{Ref|ASOS|70}} The Great Yard can be seen from the windows of the Tower of the Hand.{{Ref|AGOT|30}} Also above the steps are the [[godswood of the Red Keep|godswood]], the river walk, the small kitchen, and the pig yard.{{Ref|ACOK|18}} The [[royal sept]] and the [[Maidenvault]] are located above the serpentine steps as well.{{Ref|ASOS|6}}
+
+Relics of the [[House Targaryen|Targaryen]] dynasty, such as dusty suits of black armor, sit in some corridors.{{Ref|AGOT|20}} Doors are made of [[oak]] banded with black [[iron]].{{Ref|AGOT|22}} Sweet-smelling rushes can be spread on floors.{{Ref|ACOK|57}}{{Ref|ASOS|6}} The Red Keep is full of [[cat]]s, including those kept as pets as well as strays, like a [[Balerion (cat)|black tomcat]].{{Ref|AGOT|32}}
+
+===Great Hall===
+The [[Great Hall (Red Keep)|Great Hall]] contains the throne room of the king. The [[Iron Throne]] sits on a raised iron dais with high and narrow steps. A long carpet stretches from the throne to the hall's great [[oak]]-and-[[bronze]] doors. The cavernous Great Hall can feast a thousand people.{{Ref|AGOT|22}}  The hall is oriented north to south, with high, narrow windows on the eastern and western walls. [[Skulls of the Targaryen dragons]] once adorned the walls, but King [[Robert I Baratheon]] had them moved to a cellar and replaced with hunting tapestries at the beginning of his reign.{{Ref|AGOT|13}}{{Ref|AGOT|43}} Located behind the Iron Throne is the king's door, a private exit.{{Ref|AFFC|32}}{{Ref|AFFC|43}}
+
+The second-largest chamber in Westeros after [[Harrenhal]], more than a thousand maidens and their family members and servants overcrowded the Great Hall during the [[Maiden's Day Ball]].{{Ref|FaB|21}} [[Small council]] sessions are sometimes held in the throne room.{{Ref|ADWD|Epilogue}}
+
+===Maegor's Holdfast===
+[[Maegor's Holdfast]] is a massive square fortress inside the heart of the Red Keep. The castle-within-a-castle is situated behind walls twelve feet thick and a dry moat lined with iron spikes. Maegor's Holdfast includes the royal apartments, and the king's bedchamber contains a canopied bed and twin hearths.{{Ref|AGOT|47}} The holdfast also contains the Queen's Ballroom.{{Ref|ACOK|57}}
+
+===Tower of the Hand===
+[[File:Tower of the Hand.jpg|thumb|[[Tower of the Hand]], by Ryan Barger © Fantasy Flight Games]]
+The [[Tower of the Hand]] contains the chambers of the [[Hand of the King]] and the [[Small Hall]].{{Ref|AGOT|22}} The building has a [[solar]] and a garderobe,{{Ref|ACOK|29}} as well as tall windows.{{Ref|AGOT|39}} Below the tower is the [[chamber of the dragon mosaic]].{{Ref|ASOS|77}}
+
+===Other Buildings===
+The council chamber hosts meetings of the [[small council]]. It contains a long table,{{Ref|AGOT|51}} at the head of which may sit the king.{{Ref|ASOS|19}} The chamber is richly furnished with [[Myr]]ish carpet, a carved screen from the [[Summer Isles]], and tapestries from [[Lys]], [[Norvos]], and [[Qohor]]. The chamber's door is flanked by two [[Valyrian sphinx]]es.{{Ref|AGOT|20}} The door can be guarded by a knight of the [[Kingsguard]] when the council is in session.{{Ref|AFFC|17}}
+
+[[File:White Sword Tower.jpg|thumb|[[White Sword Tower]], by Franz Miklis © Fantasy Flight Games]]
+
+[[White Sword Tower]], located near [[Blackwater Bay]], contains the chambers of the [[Kingsguard]].{{Ref|ASOS|67}}
+
+The [[Maidenvault]] is a long, slate-roofed building located behind the [[royal sept]].{{Ref|ASOS|6}} The castle also has a library.{{Ref|ASOS|12}}
+
+The [[Kitchen Keep]] is located at a courtyard across from the castle's main kitchen. Lord [[Gyles Rosby]] has spacious apartments above the Kitchen Keep, including a large bedchamber, a solar, a bath, a dressing room, and small adjoining chambers for servants.{{Ref|ASoS|58}} The Red Keep also has a small kitchen and a pig yard.{{Ref|ACOK|18}}
+
+The [[godswood of the Red Keep]] is an acre of elm, alder and black cottonwood trees that overlook the [[Blackwater Rush]]. The [[heart tree]] is a great oak with limbs overgrown with smokeberry vines.{{Ref|AGOT|25}} Princess [[Myrcella Baratheon]] has a garden at the Red Keep.{{Ref|AGoT|57}}
+
+The [[rookery]] is the home of the [[raven]]s used by [[maesters]] of the [[Citadel]]. The [[Grand Maester]] has his chambers beneath the rookery.{{Ref|ADWD|Epilogue}}
+
+The snug apartments of Lord [[Varys]], the [[master of whisperers]], are three windowless chambers with a hearth near the northern wall. Varys sleeps on a stone bed.{{Ref|ASOS|12}}
+
+===Dungeon===
+The Traitor's Walk is a pathway{{Ref|AGOT|32}}{{Ref|ASOS|59}} leading to a squat, half-round tower.{{Ref|AFFC|27}} The top floor holds cells for prisoners kept in a degree of comfort, such as [[knight]]s or [[lord]]lings who might be ransomed, while the entrance to the dungeons sits on the ground floor. The other floors between contain rooms for the [[King's Justice]], the [[Chief Gaoler]], and the [[Lord Confessor]].{{Ref|AFFC|27}} The dungeon entrance consists of a door of hammered iron and another door of splintered grey wood.{{Ref|AFFC|27}}
+
+King [[Maegor I Targaryen]] ordered that the dungeons below the squat tower have four levels.{{Ref|ASOS|77}} The uppermost level has cells with high narrow windows where common criminals are confined together. The second level has smaller, personal cells without windows for highborn captives. Torches in the halls cast light through the bars. The third level cells, the [[black cells]], are smaller still and have doors of wood so that no light enters them,{{Ref|ASOS|77}} but they have not been used in recent years.{{Ref|AFFC|7}} The lowest level is used for torture. It is supposedly safer to go through the fourth level of the dungeons in darkness, because there are things one would not wish to see.{{Ref|ASOS|77}} The dungeon has twisting turnpike stairs and iron gates.{{Ref|ASOS|77}} A path from the lowest level leads to the [[chamber of the dragon mosaic]] below the [[Tower of the Hand]] and to the [[Blackwater Rush]].{{Ref|ASOS|77}}
+
+===Secret Passages===
+[[File:Red Keep tunnels.jpg|thumb|350px|Red Keep tunnels, by Jonny Klein © Fantasy Flight Games]]
+The Red Keep and [[Aegon's High Hill]] have a network of secret passages and tunnels. King [[Maegor I Targaryen]] had them built to enable him to make a quick escape, should his enemies ever trap him.{{Ref|ASOS|12}} The tunnels are supposedly full of traps. Some tunnels are of stone, while others are earth supported by timbers. Some of them are so small that a grown man must crawl through them. Some pass close to other rooms in the Red Keep, allowing a hidden person to eavesdrop on conversations.{{Ref|ASOS|77}}
+
+The bedchamber used by Lord [[Varys]] contains a mechanism that causes his stone slab of a bed to float up and reveal a hidden staircase.{{Ref|ASOS|12}} One secret passage leads from the bedchamber of the [[Tower of the Hand]] to the [[chamber of the dragon mosaic]] below.{{Ref|ASOS|77}}{{Ref|ADwD|1}} There is also a secret way to get out of the Red Keep onto the cliffs facing the sea. Narrow handholds, impossible to see from the ground, have been cut into the rock so one may climb down to a trail beside the [[Blackwater Rush]].{{Ref|AGOT|20}}{{Ref|ASOS|61}} Another passage out of the Red Keep passes by the cellar of the [[skulls of the Targaryen dragons]], and leads to a sewer that empties into the river.{{Ref|AGOT|32}}
+
+Maegor's Holdfast is the only building in the Red Keep that has no secret passages, as Maegor "wanted no rats in his own walls". There is one escape door, but it does not connect to any other passage in the Red Keep.{{Ref|ASOS|12}} 
+
+People familiar with the secret passages have included Maegor himself, [[Cheese (the rat-catcher)|Cheese]], Lord [[Larys Strong]], Varys and his [[little birds]], and Lord [[Petyr Baelish]].
+
+==History==
+===Construction===
+[[File:Franz Miklis red keep.jpg|thumb|The Red Keep, by Franz Miklis © Fantasy Flight Games]]
+At the start of [[Aegon's Conquest]], [[Aegon I Targaryen|Aegon the Conqueror]] landed at the mouth of the [[Blackwater Rush]]. On the highest of the three hills of the area, Aegon's Hill, he built his first fort of earth and wood,{{Ref|AGOT|18}} the [[Aegonfort]].{{Ref|AWOIAF|King's Landing}} The new city of [[King's Landing]], the capital of the [[Seven Kingdoms]], developed around the fort. In {{Date|35}} King Aegon I tore down the wooden Aegonfort so a more fitting stone castle could be raised for [[House Targaryen]], tasking his sister, Queen [[Visenya Targaryen]], and the [[Hand of the King]], Lord [[Alyn Stokeworth]], with overseeing its construction.{{Ref|TWOIAF|4|1}}{{Ref|FAB|4}}
+
+When Aegon died at [[Dragonstone]] in {{Date|37}}, he was succeeded by his son, [[Aenys I Targaryen]], who was crowned at Dragonstone and then traveled to the capital to claim the Iron Throne in the ruins of the Aegonfort.{{Ref|FAB|4}} Aenys was obsessed with the new castle, which the people of King's Landing named the Red Keep because of its stone,{{Ref|FAB|4}} but the king passed away at Dragonstone during the [[Faith Militant uprising]] in {{Date|42}}. Aenys was succeeded by his brother, [[Maegor I Targaryen|Maegor I]]. The Red Keep and the [[Sept of Remembrance]] were seized by [[Warrior's Sons]] and [[Poor Fellows]], but Maegor eventually used [[Balerion]] to destroy the [[Faith Militant]] at the sept and solidify his rule.{{Ref|TWOIAF|4|3}}
+
+Maegor took personal charge of the Red Keep's construction in {{Date|43}}. He went beyond the plans of Aegon and Aenys by adding a moated redoubt, later known as [[Maegor's Holdfast]], within the walls of the Red Keep. He also commanded that secret passages, false walls, and trapdoors be introduced to the castle and tunnels through Aegon's High Hill.{{Ref|TWOIAF|4|3}} After Prince [[Viserys Targaryen (son of Aenys I)|Viserys Targaryen]] was tortured to death by [[Tyanna of the Tower]] in {{Date|44}}, King Maegor abandoned his nephew's body in the courtyard of the Red Keep.{{Ref|TWOIAF|4|3}} Many members of [[House Harroway]] were thrown onto the spikes below Maegor's Holdfast when the king extinguished the family in {{Date|44}}.{{Ref|FAB|4}} When the castle was completed in {{Date|45}}, Maegor threw a feast for its builders, carvers, and stonemasons. After three days of feasting, however, Maegor the Cruel had all of the craftsmen killed so that only he would know the Red Keep's secrets.{{Ref|AGOT|18}}{{Ref|TWOIAF|4|3}} With the Red Keep complete, Maegor then began construction of the [[Dragonpit]]. When Maegor the Cruel was found dead on the [[Iron Throne]] in {{Date|48}}, one theory suggested that a mason familiar with the castle's secret passages had escaped Maegor's massacre and assassinated the king.{{Ref|TWOIAF|4|3}}
+
+King [[Jaehaerys I Targaryen]] chose Septon [[Barth]], who worked in the Red Keep's library, to serve as his [[Hand of the King]].{{Ref|ASOS|54}} In {{Date|95}}, Queen [[Alysanne Targaryen]] broke her hip after a fall on the serpentine steps, forcing her to then walk with a cane.{{Ref|FAB|11}} The ashes of Jaehaerys and Alysanne were interred beneath the Red Keep after their deaths.{{Ref|FAB|12}}
+
+===Dance of the Dragons===
+[[File:Red Keep Dragon Cellar by Kim Pope.jpg|thumb|350px|[[Dragon skulls]], by Kim Pope © HBO]]
+The Red Keep was a place of song and splendor during the reign of the generous King [[Viserys I Targaryen]].{{Ref|FAB|12}} The king's trusted friend, Grand Maester [[Mellos]], died while climbing the serpentine steps in {{Date|127}}.{{Ref|FAB|12}} Civil war erupted after Viserys's death with the [[Dance of the Dragons]], and many men were imprisoned in the dungeons once [[Aegon II Targaryen]] took the throne.{{Ref|FAB|13}} [[Blood and Cheese]] infiltrated the Red Keep and assassinated Prince [[Jaehaerys Targaryen (son of Aegon II)|Jaehaerys Targaryen]] to avenge the death of Prince [[Lucerys Velaryon]] at [[Storm's End]]. Afterward, the king commanded the city's ratcatchers be hanged. Ser [[Otto Hightower]] brought one hundred [[cat]]s to the Red Keep to take their place.{{Ref|FaB|14}}
+
+Queen [[Rhaenyra Targaryen]] and her spouse, Prince [[Daemon Targaryen]], landed in the outer ward of the Red Keep during the [[fall of King's Landing]].{{Ref|FAB|15}} Aegon's sister-wife, Queen [[Helaena Targaryen]], threw herself to her death from [[Maegor's Holdfast]].{{Ref|FAB|17}} Rhaenyra fled the city after the [[Storming of the Dragonpit]], and Ser [[Perkin the Flea]] claimed the abandoned Red Keep for [[Trystane Truefyre]].{{Ref|TWOIAF|4|6}} Lord [[Borros Baratheon]] recovered King's Landing for Aegon II during the [[Moon of the Three Kings]], but the king was eventually found dead within the Red Keep after the [[Battle of the Kingsroad]].{{Ref|TWOIAF|4|6}}
+
+Lord [[Cregan Stark]] administered justice for King [[Aegon III Targaryen]] during the [[Hour of the Wolf]] in {{Date|131}}.{{Ref|TWOIAF|4|7}} During the [[regency of Aegon III]] the following year, Lord [[Corlys Velaryon]] died while climbing the serpentine steps,{{Ref|FAB|20}} and young [[Falena Stokeworth]] broke her leg on the steps in {{Date|133}} before the [[Maiden's Day Ball]].{{Ref|FAB|21}} Aegon and his brother, Prince [[Viserys II Targaryen|Viserys]], were besieged in Maegor's Holdfast for eighteen days, the so-called [[secret siege]], by Ser [[Marston Waters]].{{Ref|TWOIAF|4|7}} Ser [[Lucas Lothston]], the master-at-arms of the Red Keep, was granted Harrenhal by Aegon in {{Date|151}}.{{Ref|TWOIAF|7|3|1}}
+
+===Blackfyre Rebellions===
+King [[Baelor I Targaryen]] confined his sisters in the [[Maidenvault]] when he came to the throne, claiming it would prevent any carnal thoughts.{{Ref|ASOS|6}} [[Maron Martell]], [[Prince of Dorne]], submitted to King [[Daeron II Targaryen]] before the Iron Throne, after which the pair rode to the [[Great Sept of Baelor]].{{Ref|TWOIAF|4|12}}
+
+Ser [[Quentyn Ball]], the castle's master-at-arms, helped Ser [[Daemon I Blackfyre|Daemon Blackfyre]] escape the Red Keep at the start of the [[First Blackfyre Rebellion]].{{Ref|TWOIAF|4|12}} The [[Raven's Teeth]] of Lord [[Brynden Rivers]] garrisoned the castle during the reign of King [[Aerys I Targaryen]].{{Ref|TSS}} [[Daemon II Blackfyre]] was kept hostage below the castle by Bloodraven after the [[Second Blackfyre Rebellion]].{{Ref|TWOIAF|4|13}} Ser [[Aegor Rivers]] was a prisoner in the Red Keep after the [[Third Blackfyre Rebellion]], but Bittersteel eventually escaped to the [[Free Cities]] while traveling to the [[Wall]].{{Ref|TWOIAF|4|13}} The murder of [[Aenys Blackfyre]] at the Red Keep by order of Brynden Rivers led to Bloodraven being sent to the Wall by King [[Aegon V Targaryen]].{{Ref|TWOIAF|4|15}}
+
+===The Mad King===
+[[File:Jason Engle There Are No Men Like Me.jpg|thumb|Ser [[Jaime Lannister]] and the Red Keep, by Jason Engle © Fantasy Flight Games]]
+Lord [[Tywin Lannister]], the [[Hand of the King]] to [[Aerys II Targaryen]], desired to have his brother, Ser [[Tygett Lannister]], appointed as master-at-arms of the Red Keep. The growing rift between the king and his Hand led to Ser [[Willem Darry]] instead being chosen in {{Date|170}}.{{Ref|TWOIAF|4|17}}
+
+The Mad King remained in the Red Keep for four years after the [[Defiance of Duskendale]],{{Ref|TWOIAF|4|17}} but he unexpectedly left the castle to attend the [[tourney at Harrenhal]].{{Ref|ASOS|42}}{{Ref|ADWD|67}} His heir, Prince [[Rhaegar Targaryen]], chose to reside at [[Dragonstone]] instead of the capital.{{Ref|TWOIAF|4|17}} Aerys tasked the [[Alchemists' Guild]] with using [[wildfire]] to ward off winter in {{Date|281}}, the [[Year of the False Spring]], and green flame burned on the walls of the Red Keep.{{Ref|TWOIAF|5|1}}
+
+After [[Lyanna Stark]] was abducted by Rhaegar, her brother, [[Brandon Stark]], rode into the Red Keep to challenge Rhaegar. Aerys had Brandon and his companions arrested, however, and summoned their fathers to court. The king had almost all of them murdered, with Brandon and his father, Lord [[Rickard Stark]], being executed in the throne room.{{Ref|ACOK|55}} Later during [[Robert's Rebellion]], Rhaegar rode from the Red Keep to confront Lord [[Robert I Baratheon|Robert Baratheon]],{{Ref|AFFC|8}} but the prince was slain by Robert in the [[Battle of the Trident]].{{Ref|AGOT|4}}
+
+Ser [[Jaime Lannister]], a member of the Mad King's [[Kingsguard]], held the Red Keep amid the [[Sack of King's Landing]]. Ser [[Gregor Clegane]] and Ser [[Amory Lorch]] climbed the walls of [[Maegor's Holdfast]] and slew Rhaegar's wife, Princess [[Elia Martell]], and children, Princess [[Rhaenys Targaryen (daughter of Rhaegar)|Rhaenys]] and Prince [[Aegon Targaryen (son of Rhaegar)|Aegon Targaryen]].{{Ref|ASOS|11}}{{Ref|ASOS|53}} Jaime wanted the king to surrender the castle, but Aerys instead wanted to enact his [[wildfire plot]], with [[wildfire]] having been hidden throughout the city, including the castle's cellars. Jaime slew [[Rossart]] while the [[Hand of the King]] hurried to a postern gate, and then Jaime killed Aerys before the [[Iron Throne]].{{Ref|ASOS|37}} Willem Darry eventually helped Aerys's surviving children, Prince [[Viserys Targaryen|Viserys]] and Princess [[Daenerys Targaryen|Daenerys]], flee Dragonstone before [[assault on Dragonstone|its assault]] by [[Stannis Baratheon]].{{Ref|AGOT|3}}
+
+===House Baratheon===
+King [[Robert I Baratheon]] claimed the [[Iron Throne]] after the death of King [[Aerys II Targaryen]]. Ser [[Aron Santagar]] serves as [[master-at-arms]] of the Red Keep, while Ser [[Ilyn Payne]] is the [[King's Justice]].{{Ref|AGOT|Appendix}} Grand Maester [[Pycelle]] handles the castle's [[raven]]s.{{Ref|AGOT|25}} [[Moon Boy]] and [[Orland of Oldtown]] are Robert's [[fool]] and bard, respectively.{{Ref|ASOS|Appendix}}
+
+==Recent Events==
+===''A Game of Thrones''===
+[[File:Joshua CairosNedStark.jpg|thumb|[[Eddard Stark]] in the council chambers, by Joshua Cairós © Fantasy Flight Games]]
+Lady [[Lysa Arryn]] abruptly flees the Red Keep in the night after the death of her husband, Lord [[Jon Arryn]].{{Ref|AGOT|34}} The new [[Hand of the King]], Lord [[Eddard Stark]], and his daughters, [[Sansa Stark|Sansa]] and [[Arya Stark|Arya]], take up residence in Jon's former chambers in the [[Tower of the Hand]].{{Ref|AGOT|20}}
+
+Lost in the dark cellars of the Red Keep, Arya overhears a conversation between two men who are strangers to her, [[Varys]] and [[Illyrio Mopatis]].{{Ref|AGOT|32}}{{Ref|SSM|1261}}
+
+King [[Robert I Baratheon]] is taken to his chambers in [[Maegor's Holdfast]] after having been mortally wounded by a [[boar]] in the [[kingswood]].{{Ref|AGOT|47}} After Robert dies, Queen [[Cersei Lannister]] has Eddard arrested in the throne room for plotting against King [[Joffrey Baratheon|Joffrey I Baratheon]].{{Ref|AGOT|4}} Lord Stark is thrown into the dungeon{{Ref|AGOT|58}} and Sansa is confined to the tallest tower of Maegor's,{{Ref|AGOT|51}} but Arya escapes the [[House Lannister guards|Lannister guards]] by fleeing into the dungeons.{{Ref|AGOT|50}}
+
+Robert's hunting tapestries are removed from the throne room's walls.{{Ref|AGOT|57}} Sansa is eventually granted freedom of the castle by Cersei, although the girl is not allowed to leave the Red Keep.{{Ref|AGOT|57}} Ser [[Barristan Selmy]], having been dismissed from the [[Kingsguard]],{{Ref|AGOT|57}} slays two [[gold cloaks]] in the stables while attempting to leave the Red Keep.{{Ref|AGOT|60}}{{Ref|ADWD|11}} Joffrey has the spiked heads of Eddard and other members of his retinue displayed on the castle's walls.{{Ref|AGOT|67}} Sansa briefly considers pushing Joffrey from the battlements and falling to her death, but she refrains when [[Sandor Clegane]] treats her wounded lip.{{Ref|ASOS|67}}
+
+===''A Clash of Kings''===
+[[File:Zippo514 Giant of Lannister.jpg|thumb|[[Tyrion Lannister]] rallying troops at the [[Battle of the Blackwater|Blackwater]], by zippo514 ©]]
+With the [[War of the Five Kings]] having broken out, the [[tourney on King Joffrey's name day]] is held in the Red Keep.{{Ref|ACOK|2}} [[Tyrion Lannister]], the acting Hand, has [[Vylarr]] remove the spiked heads.{{Ref|ACOK|2}} Ser [[Dontos Hollard]] meets with [[Sansa Stark]] in the [[godswood of the Red Keep|castle's godswood]] to avoid being overheard.{{Ref|ACOK|18}}
+
+When a mob of [[smallfolk]] ask for food outside the castle's gates, King [[Joffrey I Baratheon]] has his guards fire upon them.{{Ref|ACOK|20}} The royal party flees back to the Red Keep during the [[riot of King's Landing]].{{Ref|ACOK|41}}
+
+During the [[Battle of the Blackwater]], Sansa and other ladies take refuge in the Red Keep's [[royal sept]] and the [[Queen's Ballroom]].{{Ref|ACOK|57}} Queen [[Cersei Lannister]] has Ser [[Ilyn Payne]], the [[King's Justice]], on hand in the ballroom,{{Ref|ACOK|57}} and she recalls Joffrey to [[Maegor's Holdfast]] during the battle.{{Ref|ACOK|62}} The castle's bells ring to celebrate the defeat of [[Stannis Baratheon]] by Lord [[Tywin Lannister]].{{Ref|ACOK|62}} Afterward, heroes and captives are presented before Joffrey in the throne room.{{Ref|ACOK|65}}
+
+===''A Storm of Swords''===
+[[File:Cassandre Bolanshadowsandspiders.jpg|thumb|[[Varys]] spying amongst the cobwebs in the Red Keep, by Cassandre Bolan © Fantasy Flight Games]]
+Lord [[Mace Tyrell]]'s court stays in the [[Maidenvault]] during their visit to King's Landing.{{Ref|ASOS|6}} [[Tyrion Lannister]] houses Prince [[Oberyn Martell]]'s retinue from [[Dorne]] in a cornerfort away from the Tyrells.{{Ref|ASOS|53}}
+
+Sansa marries [[Tyrion Lannister]] in the Red Keep's sept, and [[Wedding of Tyrion Lannister and Sansa Stark|their wedding feast]] is held in the [[Small Hall]] afterwards.{{Ref|ASOS|28}} Tyrion and Sansa are granted Lord [[Gyles Rosby]]'s apartments in the [[Kitchen Keep]].{{Ref|ASOS|58}}
+
+King Joffrey receives wedding gifts in the Queen's Ballroom.{{Ref|ASOS|59}} Following his wedding to [[Margaery Tyrell]] at the [[Great Sept of Baelor]], Joffrey [[Purple Wedding|dies at the reception]] in the throne room.{{Ref|ASOS|60}} Tyrion is blamed for Joffrey's death and is held in a tower cell.{{Ref|ASOS|66}} Sansa escapes the Red Keep with the assistance of Joffrey's new fool, [[Dontos Hollard]].{{Ref|ASOS|61}} It is rumored that a ghostly [[direwolf]] prowls the Red Keep after Sansa's disappearance.{{Ref|ASOS|62}} Ser [[Jaime Lannister]] has sex with his sister, Queen [[Cersei Lannister]], in the royal sept, where Joffrey's body has been placed.{{Ref|ASOS|62}}
+
+Oberyn represents Tyrion in a [[trial by combat]] held in the Red Keep's outer ward, but the Red Viper is slain by Ser [[Gregor Clegane]].{{Ref|ASOS|70}} The night before Tyrion is to be executed, Jaime forces [[Varys]] to help his brother escape from the [[black cells]]. Varys then guides Tyrion to the [[chamber of the dragon mosaic]]. Tyrion climbs a secret passage to the [[Tower of the Hand]], where he kills his father, Lord [[Tywin Lannister]], the [[Hand of the King]].{{Ref|ASOS|77}}
+
+===''A Feast for Crows''===
+[[File:Xia TaptaraRedKeepServant.jpg|thumb|A servant spying in the Red Keep, by Xia Taptara © Fantasy Flight Games]]
+Queen Regent [[Cersei Lannister]] becomes paranoid after her father, Lord [[Tywin Lannister]], is found murdered in the [[Tower of the Hand]]. The queen fears that her younger brother, [[Tyrion Lannister]], is moving in secret passages, and that the vanished [[Varys]] has allied with [[Stannis Baratheon]].{{Ref|AFFC|3}} Ser [[Jaime Lannister]] and guards unsuccessfully search for Tyrion and Varys.{{Ref|AFFC|3}}{{Ref|AFFC|8}}{{Ref|AFFC|12}} The undergaoler [[Rugen]] has also disappeared.{{Ref|AFFC|7}}
+
+King [[Tommen Baratheon|Tommen I Baratheon]] weds [[Margaery Tyrell]] in [[Wedding of Tommen I Baratheon and Margaery Tyrell|a modest ceremony within the castle sept]]. After the feast in the Small Hall, Cersei has the Tower of the Hand burned to the ground with [[wildfire]].{{Ref|AFFC|12}}
+
+The queen dreams of building a new royal castle on the other side of the [[Blackwater Rush]].{{Ref|AFFC|12}} Cersei refuses to allow Ser [[Loras Tyrell]] to become the castle's new master-at-arms.{{Ref|AFFC|25}} The dying Ser [[Gregor Clegane]] and enemies of Cersei are sent by the queen to the [[black cells]] for experimentation by [[Qyburn]].{{Ref|AFFC|7}}{{Ref|AFFC|32}}
+
+===''A Dance with Dragons''===
+Ser [[Balon Swann]] informs Prince [[Doran Martell]] and his court at [[Sunspear]] that Ser [[Gregor Clegane]]'s dying screams were heard throughout the Red Keep.{{Ref|ADWD|38}}
+
+With Queen [[Cersei Lannister]] having been arrested by the [[High Sparrow]], her uncle, Ser [[Kevan Lannister]], takes up residence in the Red Keep as [[Lord Regent]]. Several accusers against [[Margaery Tyrell]] are imprisoned in dungeons under the castle.{{Ref|ADWD|54}} Cersei embarks on a [[walk of atonement]] from the [[Great Sept of Baelor]] to the Red Keep.{{Ref|ADWD|65}}
+
+The new [[Hand of the King]], Lord [[Mace Tyrell]], plans to construct a replacement Tower of the Hand triple the size of the original. Kevan and [[Pycelle]] are [[Assassinations of Pycelle and Kevan Lannister|assassinated]] by [[Varys]] and his "[[little birds]]" in the [[Grand Maester]]'s chambers below the rookery.{{Ref|ADWD|Epilogue}}
+
+==Quotes==
+[[File:Red Keep.jpg|thumb|The Red Keep in ''[[Game of Thrones]]'']]
+{{Quote|The Red Keep has its secrets, known only to the dead.{{Ref|FAB|4}}|writings of [[Gyldayn]]}}
+
+{{Quote|[[Eddard Stark|His father]] would be the [[Hand of the King]], and they were going to live in the red castle at [[King's Landing]], the castle the [[House Targaryen|Dragonlords]] had built. [[Old Nan]] said there were [[ghosts]] there, and dungeons where terrible things had been done, and [[Skulls of the Targaryen dragons|dragon heads]] on the walls.{{ref|AGOT|8}}|thoughts of [[Bran Stark]]}}
+
+{{Quote|[[Aegon I Targaryen|Aegon the Conqueror]] had commanded it built. His son [[Maegor I Targaryen|Maegor the Cruel]] had seen it completed. Afterward he had taken the heads of every stonemason, woodworker, and builder who had labored on it. Only the [[House Targaryen|blood of the dragon]] would ever know the secrets of the fortress the [[Dragonlords]] had built, he vowed.{{Ref|AGOT|18}}|thoughts of [[Catelyn Stark]]}}
+
+{{Quote|The Red Keep has ways known only to [[ghosts]] and [[spider]]s.{{Ref|AGOT|30}}|[[Varys]] to [[Eddard Stark]]}}
+
+{{Quote|The Red Keep shelters two sorts of people, Lord Eddard. Those who are loyal to [[Seven Kingdoms|the realm]], and those who are loyal only to themselves. {{Ref|AGOT|30}}|[[Varys]] to [[Eddard Stark]]}}
+
+{{Quote|[[Eddard Stark|Father]] said the Red Keep was smaller than [[Winterfell]], but in her dreams it had been immense, an endless stone maze with that seemed to shift and change behind her.{{Ref|AGOT|32}}|thoughts of [[Arya Stark]]}}
+
+{{Quote|The only palace I desire is the red castle at [[King's Landing]], my lord Pyat.{{Ref|ACOK|27}}|[[Daenerys Targaryen]] to [[Pyat Pree]]}}
+
+{{Quote|[[Blackwater Rush|The river]] that had seemed so narrow from a distance now stretched wide as a sea, but [[King's Landing|the city]] had grown gigantic as well. Glowering down from [[Aegon's High Hill]], the Red Keep commanded the approaches. Its iron-crowned battlements, massive towers, and thick red walls gave it the aspect of a ferocious beast hunched above river and streets. The bluffs on which it crouched were steep and rocky, spotted with lichen and gnarled thorny trees.{{Ref|ACOK|58}}|thoughts of [[Davos Seaworth]]}}
+
+{{Quote|No one knew the Red Keep better than [[Varys|the eunuch]].{{Ref|ASOS|67}}|thoughts of [[Jaime Lannister]]}}
+
+{{Quote|It is my day now. It is my castle and [[Seven Kingdoms|my kingdom]].{{Ref|AFFC|12}}|thoughts of [[Cersei Lannister]]}}
+
+{{Quote|My descendants shall rule here for a thousand years.{{Ref|fab|4}}|King [[Aenys I Targaryen]]}}
+
+==References==
+{{References}}
+
+[[Category:Red Keep| ]] 
+[[Category:Castles]]
+[[Category:House Targaryen]]
+[[Category:House Baratheon]]
+[[Category:King's Landing]]
+[[Category:Libraries]]
+[[Category:Red castles]]
+
+[[es:Fortaleza Roja]]
+[[fa:قلعه سرخ]]
+[[fr:Donjon Rouge]]
+[[it:Fortezza Rossa]]
+[[pt:Fortaleza Vermelha]]
+[[ru:Красный замок]]
+[[tr:Kızıl Kale]]
+[[zh:红堡]]

--- a/internal/wikitext/fixtures/test_wikitext_lg_4.txt
+++ b/internal/wikitext/fixtures/test_wikitext_lg_4.txt
@@ -1,0 +1,235 @@
+{{Redirect2|Duncan|Dunk|others with the same name}}
+{{Infobox character
+| arms = Dunk
+| arms2 = Gallows Knight
+| arms3 = Kingsguard
+| title = Ser
+| firstname = Duncan
+| epithet = the Tall
+| nametemplate = title/firstname/epithet
+| image = Dunk.jpg
+| image_caption = Dunk, by Amok © Roaring Studios
+| Alias = Dunk{{Ref|THK}}<br>Duncan the Tall{{Ref|THK}}<br>Dunk the Lunk{{Ref|THK}}<br>Dunk of Flea Bottom{{Ref|TSS}}<br>Duncan the Dim{{Ref|TSS}}<br>Ser Giant{{Ref|TMK}}<br>The Gallows Knight{{Ref|TMK}}<br>The Hanged Man{{Ref|TMK}}
+| Title = [[Knight|Ser]]{{Ref|THK}}<br>[[Lord Commander of the Kingsguard]]{{Ref|TWOIAF|4|15}}
+| Allegiance = [[House Osgrey]]<br>[[House Targaryen]]<br>[[Kingsguard]]
+| Culture = [[Crownlands]]
+| Date_of_Birth = {{Date|193}}<ref>''See the [[Years after Aegon's Conquest/Calculations Ages#Duncan the Tall|Duncan the Tall]] calculation.''</ref>
+| Place_of_Birth = [[King's Landing]]{{Ref|THK}}
+| Date_of_Death = {{Date|259}}
+| Place_of_Death = [[Summerhall]] {{s|presumed}}{{Refn|group="N"|Based on the semi-canon app ''[[A World of Ice and Fire]]'', Ser Duncan the Tall died in 259 AC during the [[tragedy at Summerhall]].{{Ref|AWOIAF|Duncan}} However, according to Dexter Sol Ansell, the actor who portrays [[Aegon V Targaryen|Egg]] in ''[[A Knight of the Seven Kingdoms (TV series)|A Knight of the Seven Kingdoms]]'', he was told by [[George R. R. Martin]] that Duncan survived the fire of Summerhall.<ref name=decider>{{Cite video | people = [https://www.youtube.com/@decider Decider] and [https://www.youtube.com/@pagesix Page Six] | year = 2026 | url = https://www.youtube.com/watch?v=UL11JAqY2m8&t=388s | title =  'AKOTSK' Stars Peter Claffey & Dexter Sol Ansell Craft Their Own Puppets  | time = 6:28 | publisher = YouTube | date = February 12, 2026}}</ref><ref name=dexsolansell>asoiaf.westeros.org: [https://asoiaf.westeros.org/index.php?/topic/166153-dex-sol-ansell-actor-who-plays-egg-in-hbos-akotsk-lets-out-massive-summerhall-spoiler/page/2/#comment-91878 Dex Sol Ansell, actor who plays Egg in HBO's AKOTSK, lets out massive Summerhall spoiler&ndash; Comment by Ran (February 13, 2026)]</ref> Subsequently, Ansell explained that "some people think they know what's going to happen [at Summerhall], but I've been speaking to George, and he hasn't decided either".<ref>Vulture (February 22, 2026): [https://www.vulture.com/article/dexter-sol-ansell-knight-of-the-seven-kingdoms-finale-interview.html Dexter Sol Ansell Has His Own Ideas About Egg's Future]</ref>}}
+| Spouse =
+| Lover = 
+| Issue = At least one son or daughter{{Ref|ssm|1257}}
+| coat-of-arms = A green shooting star above an elm tree proper on sunset{{Ref|THK}}<ref name="heraldry"/><br>(''Sunset, a shooting star vert above an elm tree proper'')
+| Books = ''[[The World of Ice & Fire]]'' (mentioned)<br>''[[The Hedge Knight]]'' (POV)<br>''[[The Sworn Sword]]'' (POV)<br>''[[The Mystery Knight]]'' (POV)<br>''[[A Storm of Swords]]'' (mentioned)<br>''[[A Feast for Crows]]'' (mentioned)<br>''[[A Dance with Dragons]]'' (mentioned)
+| Played_by = [[w:Peter Claffey|Peter Claffey]]
+| TV_series = ''[[A Knight of the Seven Kingdoms (TV series)|A Knight of the Seven Kingdoms]]'': [[A Knight of the Seven Kingdoms - Season 1|Season 1]]
+}}
+
+'''Duncan the Tall''' was a [[knight]] during the reigns of Kings [[Daeron II Targaryen|Daeron II]], [[Aerys I Targaryen|Aerys I]], [[Maekar I Targaryen|Maekar I]], and [[Aegon V Targaryen]]. Raised as '''Dunk''' in [[Flea Bottom]], he became the squire of a [[hedge knight]], Ser [[Arlan of Pennytree]]. Duncan then traveled the [[Seven Kingdoms]] as a hedge knight himself, with the young Prince Aegon, called "Egg", as his squire. The early exploits of "[[Dunk and Egg]]" are chronicled in ''[[A Knight of the Seven Kingdoms]]'', which collects ''[[The Hedge Knight]]'', ''[[The Sworn Sword]]'', and ''[[The Mystery Knight]]''. Duncan then served Aegon after he ascended the [[Iron Throne]], eventually becoming [[Lord Commander of the Kingsguard|Lord Commander]] of the [[Kingsguard]] for Aegon V.
+
+Duncan's personal arms were a green shooting star above an [[elm]] tree proper on sunset,{{Ref|THK}}<ref name="heraldry">The Citadel: [https://www.westeros.org/Citadel/Heraldry/Other/1/ Heraldry - Houseless Hedge Knights]</ref> but he also briefly used, while competing as a [[mystery knight]] in a tournament, the sigil of an unknown knight, "a hanged man swinging grim and gray beneath a gallows tree."{{Ref|TMK}}
+
+In the television adaptation ''[[A Knight of the Seven Kingdoms (TV series)|A Knight of the Seven Kingdoms]]'', Duncan is portrayed by [[Peter Claffey]].<ref>The Hollywood Reporter: [https://www.hollywoodreporter.com/tv/tv-news/game-of-thrones-hedge-knight-dunk-and-egg-cast-1235867446/ Dunk and Egg cast] (April 5, 2024)</ref>
+
+==Appearance and Character==
+{{See also|:Category:Images of Duncan the Tall|l1=Images of Duncan the Tall}}
+Duncan was an inch shy of seven feet tall.{{Ref|THK}}{{Ref|TMK}} He had thick, shaggy hair which sun-streaked in the [[summer (season)|summer]]. After the events at [[Standfast]] in {{Date|211}}, he had a dagger scar on his cheek.{{Ref|TSS}}{{Ref|TMK}} Dunk was strong and quick, and was taught jousting and swordplay.{{Ref|THK}} He was better with a sword than with a lance,{{Ref|TMK}} and even better with an axe or mace.{{Ref|TSS}}
+
+Duncan had a humble personality, and frequently thought of himself as thick-headed, recalling how Ser [[Arlan of Pennytree|Arlan]] had often said, "Dunk the lunk, thick as a castle wall", and referred to him as "slow as an [[aurochs]]".{{Ref|THK}}
+
+Having grown up in the slums of Flea Bottom, Duncan spoke with a recognizable King's Landing [[Common Tongue|accent]].{{Ref|TSS}}
+
+==History==
+===Early life===
+Duncan's earliest memories were of living as a street urchin in the [[Flea Bottom]] slums of [[King's Landing]].{{Ref|THK}} His closest friends went by the names of [[Ferret]], [[Rafe]], and [[Pudding]]. By his own admission, they were "little monsters" with Duncan, at the time still known as "Dunk", the worst of all.{{Ref|TMK}} Sometimes they would sell{{Ref|TSS}} or even dump{{Ref|TMK}} pieces of meat of dubious origin to the local pot shops that made the [[bowl of brown|bowls of brown]]. Dunk was an orphan{{Ref|THK}} who never knew either of his parents. It may be that he is a [[bastard]]. He believed his father might have been a criminal, and once hoped to someday go to the [[north]] and eventually the [[Wall]], where he could perhaps meet some tall old man who looked like him.{{Ref|TSS}}
+
+[[File: YoungDunk Arlan TMK comic.png|thumb|200px|left|Ser Arlan and Dunk in Flea Bottom, by Mike S. Miller]]
+Ser [[Arlan of Pennytree]], a [[hedge knight]], took Dunk as his new [[squire]] three or four years after the death of his previous squire, [[Roger of Pennytree]], during the [[Battle of the Redgrass Field|final battle]] of the [[First Blackfyre Rebellion]] in {{Date|196}}.{{Refn|group="N"|Duncan had been serving Ser Arlan since he was five or six years old, after the tourney at [[Storm's End]] in {{Date|200}},{{Ref|THK}} and was "no more than three or four" at the time of the Redgrass Field, in late {{Date|196}}, when Roger died.{{Ref|TSS}}{{Ref|TWOIAF|The Targaryen Kings: Daeron II}}}}{{Ref|TSS}} He found the young Dunk, aged five or six,{{Ref|THK}} in King's Landing chasing a pig and took him on.{{Ref|TMK}} Arlan raised Dunk, and together they traveled all over Westeros, except the north.{{Ref|TSS}} Though they never visited [[Pennytree]], where Arlan was from,{{Ref|TMK}} they served Lord [[Leo Tyrell (Longthorn)|Leo Tyrell]] at [[Highgarden]] during one of the first few years that Dunk served Arlan,{{Ref|THK}} visited [[King's Landing]] in {{Date|205}},{{Ref|TMK}} served [[Lord Florent]] for half a year and joined [[Lord Dondarrion (father of Manfred)|Lord Dondarrion]] in the hunt for the [[Vulture King (Daeron II)|Vulture King]], both in {{Date|206}}, and visited [[Lannisport]] in {{Date|208}},{{Ref|THK}} amongst other places. As well, Duncan accompanied Arlan when he was one of several [[knight]]s hired by a Dornish merchant who wanted to travel from [[Lannisport]] to the [[Prince's Pass]] in [[Dorne]].{{Ref|TSS}}
+
+Dunk learned sword-fighting from Ser Arlan,{{Ref|THK}} though he still recalls his fighting experience from Flea Bottom as well.{{Ref|THK}}{{Ref|TSS}} Ever since the first time that Arlan had let Duncan hold a sword, Duncan had dreamt of becoming a knight of the [[Kingsguard]].{{Ref|TMK}}
+
+Dunk was not sure exactly how old he was because he grew up as an abandoned orphan in the streets of King's Landing, and his unusually large height from a young age made it difficult to guess. By 209 AC he loosely thought he must be about 16 or 17 years old, which would place his birth somewhere between 191 to 193 AC.{{Ref|THK}}
+
+===Tourney at Ashford Meadow===
+[[File:Dunk and Egg by Even Mehl Amundsen.jpg|thumb|Dunk and [[Aegon V Targaryen|Egg]], by Even Mehl Amundsen ©]]
+In {{Date|209}}, a [[tourney]] was to be held at [[Ashford Meadow]] in the [[Reach]]. Ser [[Arlan of Pennytree]] died on the way to [[Ashford|Ashford Castle]], however, and after Dunk had buried the [[hedge knight]], he decided to compete in the [[tourney at Ashford Meadow]] in Arlan's stead. At [[inn near Ashford|an inn]] along the way, Dunk met a [[Daeron Targaryen (son of Maekar I)|drunken man]] who claimed to have dreamed about him, and who became distraught at the sight of him. Dunk also met a bald-headed boy who begged Dunk to be allowed to become his [[squire]] when Dunk left. Dunk refused, left, and shortly thereafter arrived at Ashford.{{ref|THK}}
+
+Duncan made camp, and that evening discovered the bald boy from the inn at his camp. When the boy assumed that Dunk's name was short for Duncan, Dunk agreed, calling himself Ser Duncan the Tall, for his height and because it sounded powerful. The boy claimed to be called "Egg" and said he came from [[King's Landing]], causing Dunk to believe the boy was an orphan from [[Flea Bottom]], just like he had been. Because he did not have a squire, Dunk accepted Egg as his squire for the duration of the tourney. That night, in their camp under an [[elm]] tree, Dunk saw a green [[astronomy|falling star]], which he believed was lucky.{{Ref|THK}}
+
+Once at the tourney grounds, Duncan was forced to sell [[Sweetfoot]], one of his [[horse]]s, and Arlan's old [[armor]], in order to buy armor of his own from [[Steely Pate]]. He met a puppeteer named [[Tanselle]], who was performing at a stall on the tourney grounds. The day after Dunk's arrival, he went to register for the tourney, which required [[knighthood]] to participate. Identifying himself as Ser Duncan the Tall, Dunk told [[Plummer]], [[Lord Ashford]]'s steward, how Arlan had knighted him before his death. Several of his thoughts and actions, as well as other facts, however, suggest that his tale is not completely true.{{Refn|group="N"|name=knighthood|There is a Noreascon report{{Ref|ssm|1307}} with a paraphrased statement by [[George R. R. Martin]], confirming that Duncan had not been knighted by Ser Arlan. Besides this [[So Spake Martin|SSM]], other indications have been laid out by readers. Immediately after burying Arlan, Duncan considers finding another knight to squire for,{{Ref|THK}} which is at odds with his supposed new-made knighthood. Duncan also becomes uncomfortable at several occasions when his knighting is brought up, such as when Lady [[Rohanne Webber]] asks if he was knighted by Arlan, and Duncan looks at his feet while saying "No one else was like to do it."{{Ref|TSS}} Duncan wonders if his ears have turned red when [[Plummer]] asks if he is a knight. Duncan is extremely hesitant to knight [[Raymun Fossoway]], feeling both relieved and guilty when [[Lyonel Baratheon]] steps in to knight Raymun instead.{{Ref|THK}} Lastly, Duncan admits to himself that "He knew what it was like to want something so badly that you would tell a monstrous lie just to get near it."{{Ref|THK}} Readers have suspected that this refers to his lie about his knighthood.}} Plummer suggested that Duncan find someone to vouch for him and return the next day.{{ref|THK}}
+
+Unable to find anyone, Duncan returned to the castle the next day, where he accidentally interrupted Prince [[Baelor Targaryen (son of Daeron II)|Baelor]] and Prince [[Maekar I Targaryen|Maekar Targaryen]], who were occupied with the missing Princes [[Daeron Targaryen (son of Maekar I)|Daeron]] and [[Aegon V Targaryen|Aegon]], two of Maekar's sons. After Duncan explained his problem to the princes, Baelor recalled jousting against Arlan years before, and vouched for Duncan, allowing his participation. Since Dunk's shield displayed the winged chalice arms of the late Arlan, Baelor said he could not bear the sigil himself, as he was not Arlan's trueborn son. Dunk paid Tanselle to paint over the shield with a new design, a green shooting star above an elm tree at sunset; a sunset because Arlan liked them, an elm for the tree by his camp, and a shooting star for the lucky one he had seen.{{Ref|THK}}
+
+When Tanselle was attacked by Prince [[Aerion Targaryen]], Duncan rushed to her defense, attacking the prince in the process. When Aerion's guards intervened, Egg protected Duncan from further harm by revealing his identity as Prince Aegon. Duncan was arrested and brought to the castle, where Prince Baelor informed him how Prince Daeron had claimed to his father that the missing Aegon had been kidnapped by a robber knight, while Aerion was twisting the puppeteer story into treason. Due to the lies of both Aerion and Daeron, Maekar became furious with Duncan. Baelor was forced to allow Aerion a trial, and Aerion demanded a [[trial of seven]].{{Ref|THK}}
+
+With help from Aegon, Duncan found six allies: Ser [[Robyn Rhysling]], Ser [[Humfrey Hardyng]], Lord [[Lyonel Baratheon]], Ser [[Humfrey Beesbury]], the newly-knighted [[Raymun Fossoway]], and Prince Baelor. Aerion was supported by Daeron, Maekar, Ser [[Steffon Fossoway]], Ser [[Willem Wylde]], Ser [[Donnel of Duskendale]], and Ser [[Roland Crakehall (Kingsguard)|Roland Crakehall]], the latter three being knights of the [[Kingsguard]]. To his surprise, Duncan discovered that the [[smallfolk]] supported him, as he had remembered his vows as a knight{{Ref|THK}} ("protecting the weak and defending the innocent"){{Ref|ACOK|32}}{{Ref|ACOK|52}}{{Ref|ADWD|27}} by protecting Tanselle. During the combat, Duncan eventually found himself facing Aerion one on one, and he managed to best Aerion by using his strength and his fighting skills from Flea Bottom. Duncan forced Aerion to yield. As Daeron had already faked his defeat—as he had promised Duncan the day before—Duncan was declared cleared free of all charges.{{Ref|THK}}
+
+Humfrey Beesbury was slain in the fighting, and Humfrey Hardyng died from his wounds in the night. Prince Baelor was mortally wounded as well by his own brother, Prince Maekar, leaving Duncan feeling extremely guilty. Maekar offered Duncan a place at [[Summerhall]] so his son Aegon could squire for Duncan. While Duncan agreed to take the prince as his squire, he insisted on remaining a hedge knight, convinced it would teach Egg humility. The next morning Aegon departed with Duncan, saying his father had told him to serve Duncan.{{Ref|THK}}
+
+===On the road===
+[[File:Marc Simonetti DunkEggtravels.jpg|thumb|Duncan and [[Aegon V Targaryen|Aegon]] traveling, by Marc Simonetti ©]]
+Duncan and Aegon traveled to [[Dorne]], passing through the [[Prince's Pass]] and eventually reaching [[Vaith]], where Duncan accidentally insulted Lady [[Cassella Vaith]], the first highborn woman he had ever met. During the crossing of the desert, Duncan's horse [[Chestnut]] died,{{Ref|TSS}} and he and Aegon had to ride double on [[Thunder (horse)|Thunder]].{{Ref|TSS}} While in {{Date|209}} and {{Date|210}} the [[Great Spring Sickness]] ran its course through Westeros, Duncan and Aegon were able to avoid encountering this plague as they were in Dorne, one of the two places where the plague had not come.{{Ref|TSS}}
+
+Duncan and Aegon took a poleboat down the [[Greenblood]] to [[Planky Town]], where they took passage on the galleas ''[[White Lady]]'' to [[Oldtown]].{{Ref|TSS}}{{Ref|TMK}} Aboard the ship, Duncan had his first experience of combat at sea when he helped repel some raiders.{{Ref|TMK}} In Oldtown, Aegon's brother [[Aemon Targaryen (son of Maekar I)|Aemon]] measured Duncan, and found he was an inch short of seven feet.{{Ref|TSS}}
+
+At some point, Duncan and Aegon were gifted a mule, [[Maester (mule)|Maester]], by one of Aegon's brothers,{{Ref|TSS}} presumably Aemon.<ref group="N" name=Maester>The mule was almost certainly given by Aemon, as its name is "Maester", and Aegon and Duncan have been mentioned to have visited with Aemon in Oldtown, whereas no mention is made of Aegon encountering his brother Daeron, while his brother Aerion is still in Lys. If Aemon gave Dunk the mule, it was in Oldtown, sometime after they visited Vaith.</ref>
+
+===Service at Standfast===
+Duncan and Aegon took service with Ser [[Eustace Osgrey]], a poor and broken [[landed knight]], at [[Standfast]] in the [[Reach]]. Also employed was Ser [[Bennis of the Brown Shield]], an old acquaintance of Duncan from his time with Arlan. Duncan and Bennis discovered that peasants of the widowed [[Rohanne Webber]], [[Lady of Coldmoat]] had dammed the [[Chequy Water]]. Bennis provoked Rohanne by cutting the cheek of one of her peasants. Duncan and Bennis began training a small levy of peasants for Eustace.
+
+Since Eustace refused to travel to [[Coldmoat]], Duncan went to the castle to try to reason with Lady Webber. Though sexual tension charged their meeting, Rohanne refused Duncan and told him about Eustace's support of [[Daemon I Blackfyre|Daemon Blackfyre]] during the [[First Blackfyre Rebellion|Blackfyre Rebellion]]. Shocked by the revelation, Duncan attempted to leave Eustace's service, but a fire in the nearby woods caused him to suspect that Rohanne had already started her campaign against Eustace.{{Ref|TSS}}
+
+Duncan knew that the battle was a lost cause. He disbanded Eustace's meager levies, but promised to be by his side when he faced Rohanne. Meeting with her forces, Duncan cut his own cheek, claiming he was the one who attacked Rohanne's peasant. Lady Webber and Ser Eustance refused to back down, however, and they decided upon [[trial by combat]]. Duncan represented the elderly Eustace, and Rohanne's champion was her overbearing [[castellan]], Ser [[Lucas Inchfield]]. Duncan's wrestling ability compensated for his lack of swordsmanship, and he managed to kill Lucas Longinch, though Duncan received major wounds himself and almost drowned in the stream in which they had been fighting.{{Ref|TSS}}
+
+After recuperating, Duncan discovered that Eustace and Rohanne had settled their differences and decided to marry. Duncan felt rejected, but was confronted by Rohanne shortly before he left. He took one kiss from Rohanne and cut off a length of her signature braid as a keepsake, after which he and Aegon took their leave.{{Ref|TSS}}
+
+===Wedding Tourney at Whitewalls===
+[[File:The mystery knight by grr martin by marcsimonetti.jpg|thumb|Duncan as a [[mystery knight]], with his squire, [[Aegon V Targaryen|Aegon]], by Marc Simonetti ©]]
+Duncan and Aegon traveled to the [[riverlands]], where they visited [[Stoney Sept]]. Though they had been on their way to take up service with Lord [[Beron Stark]] against the [[ironborn]] on the [[north]]ern coast, they changed their destination after a chance meeting on the road. They encountered a group led by [[Gormon Peake]], [[Lord of Starpike]], Lord [[Alyn Cockshaw]], and a hedge knight named Ser [[Daemon II Blackfyre|John the Fiddler]]. The latter invited Duncan to attend the wedding of [[Ambrose Butterwell]], [[Lord of Whitewalls]] to [[Lady Frey (wife of Ambrose Butterwell)|the daughter]] of [[Lord Frey]], [[Lord of the Crossing]], stating that the victor's prize at the celebratory [[wedding tourney at Whitewalls]] was to be a [[dragon egg]]. Though the company traveled on without him, Duncan decided to go as well, and he befriended the fellow hedge knights Ser [[Kyle the Cat]], Ser [[Maynard Plumm]], and Ser [[Glendon Ball]] on his way to [[Whitewalls]].{{Ref|TMK}}
+
+At Whitewalls, Aegon became suspicious about the intentions of the wedding, and he informed Duncan that the majority of the nobles present had fought for [[House Blackfyre]] during the [[First Blackfyre Rebellion|Blackfyre Rebellion]]. Duncan later had an encounter with John the Fiddler, who told him that Duncan had appeared to him in a dream in which Duncan had worn the all white armor of the [[Kingsguard]]. The Fiddler said his dreams always came true, stating that he had dreamed his brothers dead once, and though they had not believed him, they had died. The Fiddler also informed Duncan that he had dreamed about a [[dragon]] hatching from an egg at Whitewalls.{{Ref|TMK}}
+
+Duncan entered the joust as the Gallows Knight, a [[mystery knight]] named for the hanged man sigil on his shield, which he had bought to replace the one destroyed by the Longinch but had not had time to have painted with his own arms. Duncan was defeated in his first tilt by Ser [[Uthor Underleaf]], who confessed that someone had attempted to bribe him to kill Duncan in the final tilt. Whilst searching for Aegon, Duncan ran into Glendon, who had been far more successful than Duncan during the tourney, and invited him to come north after the tourney, which Glendon declined. Glendon told Duncan that Lord Peake had offered him a place at [[Starpike]], on the condition that Glendon would let the Fiddler win. Glendon had refused, angering Gormon. Duncan next ran into the Fiddler, and began to realize John's true identity, as well as that the tourney had been rigged as to make the Fiddler victorious.{{Ref|TMK}}
+
+Lord Peake accused Glendon Ball of stealing the dragon egg, and the youth was imprisoned. When Duncan attempted to intervene, Alyn Cockshaw pulled him back, telling Duncan to follow him, if he wanted to find Aegon. Alyn attempted to kill Duncan out of jealousy for the attention the Fiddler had shown Duncan. Though injured, Duncan threw Alyn down a well to drown, an action witnessed by Maynard Plumm. Maynard helped Duncan see to his injuries and informed him of Aegon's location.{{Ref|TMK}}
+
+Aegon falsely told Lord Butterwell that he and Duncan were spies sent to investigate the tournament and that his father, Prince [[Maekar I Targaryen|Maekar Targaryen]], was on his way with an army. Frightened, Ambrose pled for his innocence. Ser [[Tommard Heddle]] attempted to seize Aegon in the sept, but was slain by Duncan in the combat that ensued. Duncan ordered Aegon to ride for [[Maidenpool]], and he confronted the Fiddler, calling him by his true name, [[Daemon II Blackfyre|Daemon]]. Duncan accused Lord Peake of bribing the contestants in Daemon's favor, and of falsely charging Glendon with the theft of the dragon egg. Furious about the accusations, Daemon challenged Glendon with a joust as a means of [[trial by combat]].{{Ref|TMK}}
+
+Glendon defeated Daemon Blackfyre easily early the next morning, and moments later a loyalist army led by Lord [[Brynden Rivers]], the [[Hand of the King]], arrived at Whitewalls. Daemon was arrested, and those who had supported him executed or punished, causing the [[Second Blackfyre Rebellion]] to be suppressed before it had even begun. Lord Brynden allowed Duncan and Aegon to continue their travels, and hinted as to how the dragon's egg had been stolen, leading Duncan to realize the involvement of the [[dwarf]]s who had performed at the wedding.{{Ref|TSS}}
+
+===Later life===
+[[File:ChaseStone duncantall trial by battle.jpg|thumb|350px|Ser Duncan the Tall fighting Lord [[Lyonel Baratheon]] in a [[trial by combat]], as depicted by Chase Stone in ''[[The World of Ice & Fire]]'']]
+An unknown amount of time after Whitewalls, Duncan and Aegon visited [[Winterfell]].<ref>[[Not a Blog]]: ''[https://georgerrmartin.com/notablog/2014/04/15/dunk-and-egg/ Dunk and Egg]'' (April 15, 2014)</ref>
+
+Presumably in honor of Ser Duncan, Prince [[Aegon V Targaryen|Aegon Targaryen]] named his firstborn son and heir [[Duncan Targaryen|Duncan]] (however, when asked about it, [[George R. R. Martin]] refused to answer).{{Ref|SSM|1105}} Prince Duncan was called "Duncan the Small".{{Ref|ASOS|67}}
+
+Both he and Aegon had some involvement during the [[Peake Uprising]], where Aegon's father was killed.<ref>[[So Spake Martin]]: [http://www.westeros.org/Citadel/SSM/Entry/Chicon_7_Reading Chicon 7 Reading (September 2, 2012)]</ref>
+
+In late {{Date|233}}, after Aegon had ascended the throne as [[Aegon V Targaryen]], Duncan escorted the king's brother, Maester [[Aemon Targaryen (son of Maekar I)|Aemon]], to [[Eastwatch-by-the-Sea]], where Aemon was going to join the [[Night's Watch]].{{Ref|AFFC|15}}
+
+Duncan eventually joined the [[Kingsguard]]. While it is unknown when exactly he took his vows, the first known mention of him as a Kingsguard knight is in {{Date|236}}.{{Ref|TWOIAF|4|15}}
+
+In {{Date|236}}, Ser Duncan fought in the [[Fourth Blackfyre Rebellion]] and personally slew [[Daemon III Blackfyre]], the [[House Blackfyre|Blackfyre Pretender]].{{Ref|TWOIAF|4|15}}
+
+In {{Date|239}}, when Prince [[Duncan Targaryen]] broke his betrothal to Lord [[Lyonel Baratheon]]'s daughter and married a commonborn girl known as [[Jenny of Oldstones]] instead, the enraged Lyonel renounced his fealty to the [[Iron Throne]]. Duncan served as King Aegon V's champion in the [[trial by combat]], in which he bested Lyonel, thereby ending his short rebellion.{{Ref|TWOIAF|4|15}}{{Ref|TWOIAF|7|8|4}}
+
+In {{Date|252}} or {{Date|253}} Duncan, by then [[Lord Commander of the Kingsguard]], participated in a [[winter tourney at King's Landing]], where he was defeated by a sixteen-year-old [[Barristan Selmy]].{{Ref|ASOS|67}}
+
+In {{Date|259}}, Duncan apparently perished in the [[tragedy of Summerhall]],  along with King Aegon V and Prince Duncan, among others.{{Ref|AWOIAF|Duncan}}{{Ref|TWOIAF|4|15}} Little is known about the events of the tragedy, but it seems that the Lord Commander's valor saved some of the survivors from dying in the great fire that consumed [[Summerhall]].{{Ref|TWOIAF|4|15}}
+
+==Recent Events==
+===''A Storm of Swords''===
+While in the Round Room of [[White Sword Tower]], Ser [[Jaime Lannister]] admires previous men who served as [[Lord Commander of the Kingsguard]], including Duncan. He also reads Ser [[Barristan Selmy]]'s entry in the [[White Book]], which states Barristan defeated Duncan during the [[winter tourney at King's Landing]] in which Barristan had participated as a [[mystery knight]].{{Ref|ASOS|67}}
+
+===''A Feast for Crows''===
+For unknown reasons, a shield with Dunk's original arms came to reside in the armory of Lord [[Selwyn Tarth]] at [[Evenfall Hall]]. While at [[Duskendale]], Selwyn's daughter, [[Brienne Tarth|Brienne]], remembering the arms, has them painted on her shield so she can travel the [[crownlands]] and [[riverlands]] incognito.{{Ref|AFFC|9}}
+
+Maester [[Aemon Targaryen (son of Maekar I)|Aemon]] relates that when he joined the [[Night's Watch]], his brother [[Aegon V Targaryen|Egg]] insisted that Ser Duncan accompany him to [[Eastwatch]].{{Ref|AFFC|15}} Aemon also dreams of his youth in [[Oldtown]], a time when he was drinking at the [[Quill and Tankard]] with Egg and "that big knight he served".{{Ref|AFFC|26}}
+
+===''A Dance with Dragons''===
+While in the [[cave of the three-eyed crow]], [[Bran Stark]] has visions of the past looking through the [[heart tree]] in the [[godswood of Winterfell]]. Among the visions is a slender brown-haired girl kissing a knight as tall as [[Hodor]],{{Ref|ADWD|34}} possibly Duncan.
+
+==Steeds==
+At the time of the [[tourney at Ashford Meadow]] in ''[[The Hedge Knight]]'', Dunk owned three horses which he had inherited from Ser [[Arlan of Pennytree]]:
+*[[Thunder (horse)|Thunder]], a destrier
+*[[Chestnut]], a stot which died between ''[[The Hedge Knight]]'' and ''[[The Sworn Sword]]''{{Ref|TSS}}
+*[[Sweetfoot]], a female palfrey which he sold so he could buy armor and a greathelm.{{Ref|THK}}
+
+As his adventures progressed, Duncan acquired:
+*[[Maester (mule)|Maester]], a mule he received as a gift from one of Egg's brothers,{{Ref|TSS}} presumably Aemon<ref group="N" name=Maester/>
+*[[Rain (horse)|Rain]],{{Ref|TMK}} a palfrey he received as a gift from [[Rohanne Webber]].{{Ref|TSS}}
+
+==Behind the Scenes==
+[[George R. R. Martin]] has stated that readers have met a descendant of Dunk in ''[[A Song of Ice and Fire]]''.{{Ref|ssm|1257}} He later stated that he gave a strong hint to Dunk's descendant in ''[[A Feast for Crows]]''.{{Ref|ssm|1363}} Given that in ''A Feast for Crows'', [[Brienne of Tarth|Brienne]] recalls finding a shield with Dunk's sigil in the armories of [[Tarth]],{{Ref|AFFC|9}} it was widely speculated but not confirmed that she is descended from Duncan the Tall. However, in 2016 at Balticon, Martin confirmed Brienne's descent, stating that the exact relationship between Duncan and Brienne would be "revealed in time".<ref>The Wertzone: [http://thewertzone.blogspot.nl/2016/05/george-rr-martin-confirms-game-of.html George R.R. Martin confirms GAME OF THRONES/SONG OF ICE AND FIRE fan theory] (May 29, 2016)</ref>
+
+According to Dexter Sol Ansell, the actor who portrays [[Aegon V Targaryen|Egg]] in ''[[A Knight of the Seven Kingdoms (TV series)|A Knight of the Seven Kingdoms]]'', he was told by [[George R. R. Martin]] that Ser Duncan the Tall survived the [[tragedy at Summerhall]].<ref name=decider/><ref name=dexsolansell/> However, whether Martin actually intends to introduce this notion in the books and its possible effect on the story remain a mystery.
+
+==Quotes by Duncan==
+[[File:Dunk first still from AKOTSK.png|thumb|400px|Peter Claffey as Duncan the Tall in HBO's ''[[A Knight of the Seven Kingdoms (TV series)|A Knight of the Seven Kingdoms]]'']]
+{{Quote|'''Egg''': If you took me, I could squire for you.<br>
+'''Dunk''': I have no need of a squire.<br>
+'''Egg''': Every [[knight]] needs a squire. You look as though you need one more than most.<br>
+'''Dunk''' And you look as though you need a clout in the ear, it seems to me.{{Ref|THK}}|[[Aegon V Targaryen|Egg]] and Dunk}}
+
+{{Quote|'''Egg''': I have never heard of any Ser Duncan the Tall.<br>
+'''Dunk''': Do you know every [[knight]] in the [[Seven Kingdoms]], then?<br>
+'''Egg''': The good ones.<br>
+'''Dunk''': I'm as good as any. After [[tourney at Ashford Meadow|the tourney]], they'll all know that.{{Ref|THK}}|[[Aegon V Targaryen|Egg]] and Dunk}}
+
+{{Quote|'''Duncan''': The old man, Ser [[Arlan of Pennytree|Arlan]], he used to say I was thick as a castle wall and slow as an [[aurochs]].<br>
+'''Baelor''': And strong as an aurochs, by the look of you.{{Ref|THK}}|Duncan and [[Baelor Targaryen (son of Daeron II)|Baelor Targaryen]]}}
+
+{{Quote|'''Duncan''': What color paint do you have?<br>
+'''Tanselle''': I can mix paints to make any color you want.<br>
+'''Duncan''': The field should be the color of sunset. [[Arlan of Pennytree|The old man]] liked sunsets. And the device...<br>
+'''Egg''': An [[elm]] tree. A big elm tree, like the one by the pool, with a brown trunk and green branches.<br>
+'''Duncan''': Yes. That would serve. An elm tree... but with a [[astronomy|shooting star]] above.{{Ref|THK}}|Duncan, [[Tanselle]], and [[Aegon V Targaryen|Egg]]}}
+
+{{Quote|'''Duncan''': What am I to [[smallfolk|them]]?<br>
+'''Pate''': A [[knight]] who remembered his vows.{{ref|THK}}|Duncan and [[Steely Pate]]}}
+
+{{Quote|[[Oak]] and [[iron]], guard me well, or else I'm dead and doomed to hell.{{Ref|THK}}|thoughts of Duncan}}
+
+{{Quote|'''Rohanne''': Did you come to [[knighthood]] on some battlefield, Ser Duncan? Your speech suggests that you were not born of noble blood, if you will forgive my saying so.<br>
+'''Duncan''': A [[hedge knight]] named Ser [[Arlan of Pennytree]] took me on to squire for him when I was just a boy. He taught me chivalry and the arts of war.<br>
+'''Rohanne''': And this same Ser Arlan knighted you?<br>
+'''Duncan''': No one else was like to do it.{{Ref|TSS}}|[[Rohanne Webber]] and Duncan}}
+
+{{Quote|'''Rohanne''': If you were better born, I'd marry you.<br>
+'''Duncan''': Aye, m'lady. And if pigs had wings and scales and breathed flame, they'd be as good as [[dragon]]s.{{Ref|TSS}}|[[Rohanne Webber]] and Duncan}}
+
+==Quotes about Duncan==
+{{Quote|'''Maekar''': Brother, have you taken leave of your senses? This man attacked [[Aerion Targaryen|my son]].<br>
+'''Baelor''': This man protected [[Tanselle|the weak]], as every [[true knight]] must. Let [[Faith of the Seven|the gods]] determine if he was right or wrong.{{Ref|TSS}}|[[Maekar I Targaryen|Maekar Targaryen]] and [[Baelor Targaryen (son of Daeron II)|Baelor Targaryen]]}}
+
+{{Quote|Dunk the lunk, [[Arlan of Pennytree|Pennytree]] used to call you. I recall. Lunks shouldn't try and think, their heads is too bloody thick for such.{{Ref|TSS}}|[[Bennis of the Brown Shield]] to Duncan}}
+
+{{Quote|I [[dreams|dreamed]] that you were all in white from head to heel, with a long pale cloak flowing from those broad shoulders. You were a White Sword, ser, a Sworn Brother of the [[Kingsguard]], the greatest knight in all the [[Seven Kingdoms]], and you lived for no other purpose but to guard and serve and please your king.{{Ref|TMK}}|[[Daemon II Blackfyre|John the Fiddler]] to Duncan}}
+
+{{Quote|Think on my offer, ser. The snail may leave a trail of slime behind him, but a little slime will do a man no harm… whilst if you dance with [[House Targaryen|dragons]], you must expect to burn.{{Ref|TMK}}|[[Uthor Underleaf]] to Duncan}}
+
+==Notes==
+{{Notes}}
+
+==References==
+{{References}}
+
+{{S-start}}
+{{S-vac|unknown|parameter=before|unknlast=[[Aemon Targaryen (son of Viserys II)|Aemon Targaryen]]}}
+{{S-ttl|title=[[Lord Commander of the Kingsguard]]|years=?–{{Date|259}}|under=[[Aegon V Targaryen]]}}
+{{S-aft|after=[[Gerold Hightower]]}}
+{{S-end}}
+
+{{Kingsguard of Aegon V}}
+{{Lords Commander of the Kingsguard}}
+{{Aegon V small council}}
+
+[[Category:193 AC births]]
+[[Category:259 AC deaths]]
+[[Category:Casualties of the Tragedy at Summerhall]]
+[[Category:Characters from the Crownlands]]
+[[Category:Characters with brown hair]]
+[[Category:Hedge knights]]
+[[Category:House Osgrey retainers]]
+[[Category:House Targaryen retainers]]
+[[Category:Knights]]
+[[Category:Lords Commander of the Kingsguard]]
+[[Category:Lowborn nobles]]
+[[Category:Members of Aegon V Targaryen's court]]
+[[Category:Members of the Kingsguard]]
+[[Category:Mystery knights]]
+[[Category:POV characters]]
+[[Category:Six-footers]]
+[[Category:Squires]]
+[[Category:Sworn shields]]
+[[Category:Sworn swords]]
+[[Category:Veterans of the Fourth Blackfyre Rebellion]]
+
+[[es:Duncan]]
+[[fr:Dunk]]
+[[it:Duncan]]
+[[pt:Duncan]]
+[[ru:Дункан Высокий]]
+[[tr:Uzun Duncan]]
+[[zh:“高个”邓肯]]

--- a/internal/wikitext/grammar.go
+++ b/internal/wikitext/grammar.go
@@ -48,16 +48,16 @@ var grammar = map[string]TokenGrammar{
 	"=":      {Token: heading_token, State: heading},
 }
 
-var matcherFunctions = map[string]func(*int, *[]string) (TokenGrammar, bool){
-	"[": matchNext,
-	"]": matchNext,
-	"{": matchThisOrNext,
-	"}": matchThisOrNext,
-	"=": matchMany,
+var matcherFunctions = map[byte]func(*int, *[]byte) (TokenGrammar, bool){
+	byte('['): matchNext,
+	byte(']'): matchNext,
+	byte('{'): matchThisOrNext,
+	byte('}'): matchThisOrNext,
+	byte('='): matchMany,
 }
 
 // Matches double characters in sequence (ie. `[[`)
-func matchNext(i *int, chars *[]string) (TokenGrammar, bool) {
+func matchNext(i *int, chars *[]byte) (TokenGrammar, bool) {
 	curr := (*chars)[*i]
 	if !canLookAhead(*i, chars) {
 		return TokenGrammar{}, false
@@ -68,34 +68,34 @@ func matchNext(i *int, chars *[]string) (TokenGrammar, bool) {
 		return TokenGrammar{}, false
 	}
 
-	return getTokenMatch(curr+next, i)
+	return getTokenMatch([]byte{curr, next}, i)
 }
 
-func matchThisOrNext(i *int, chars *[]string) (TokenGrammar, bool) {
+func matchThisOrNext(i *int, chars *[]byte) (TokenGrammar, bool) {
 	curr := (*chars)[*i]
 	if !canLookAhead(*i, chars) {
-		return getTokenMatch(curr, i)
+		return getTokenMatch([]byte{curr}, i)
 	}
 	next := (*chars)[*i+1]
 	if curr != next {
-		return getTokenMatch(curr, i)
+		return getTokenMatch([]byte{curr}, i)
 	}
 
 	return matchNext(i, chars)
 }
 
-func matchMany(i *int, chars *[]string) (TokenGrammar, bool) {
+func matchMany(i *int, chars *[]byte) (TokenGrammar, bool) {
 	curr := (*chars)[*i]
 	if !canLookAhead(*i, chars) {
-		return getTokenMatch(curr, i)
+		return getTokenMatch([]byte{curr}, i)
 	}
 
-	matches := curr
+	matches := []byte{curr}
 	match := true
 	j := 1
 	for match {
 		if !canLookAhead(*i+j, chars) {
-			matches += curr
+			matches = append(matches, curr)
 			match = false
 			break
 		}
@@ -104,23 +104,23 @@ func matchMany(i *int, chars *[]string) (TokenGrammar, bool) {
 			match = false
 			break
 		}
-		matches += curr
+		matches = append(matches, curr)
 		j++
 	}
 
 	return getTokenMatch(matches, i)
 }
 
-func canLookAhead(i int, chars *[]string) bool {
+func canLookAhead(i int, chars *[]byte) bool {
 	return len(*chars) > i+1
 }
 
-func canLookBehind(i int, chars *[]string) bool {
+func canLookBehind(i int) bool {
 	return i-1 >= 0
 }
 
-func getTokenMatch(key string, i *int) (TokenGrammar, bool) {
-	rule, ok := grammar[key]
+func getTokenMatch(key []byte, i *int) (TokenGrammar, bool) {
+	rule, ok := grammar[string(key)]
 	if !ok {
 		return TokenGrammar{}, false
 	}

--- a/internal/wikitext/grammar.go
+++ b/internal/wikitext/grammar.go
@@ -1,5 +1,7 @@
 package wikitext
 
+import "bytes"
+
 type TokenType string
 
 const (
@@ -32,29 +34,6 @@ type TokenGrammar struct {
 }
 
 var TEXT_TOKEN TokenGrammar = TokenGrammar{Token: text_token, State: text}
-
-var grammar = map[string]TokenGrammar{
-	"[[":     {Token: link_start, State: link},
-	"]]":     {Token: link_end, State: link},
-	"{{":     {Token: template_start, State: template},
-	"}}":     {Token: template_end, State: template},
-	"{":      {Token: table_start, State: table},
-	"}":      {Token: table_end, State: table},
-	"======": {Token: heading_token, State: heading},
-	"=====":  {Token: heading_token, State: heading},
-	"====":   {Token: heading_token, State: heading},
-	"===":    {Token: heading_token, State: heading},
-	"==":     {Token: heading_token, State: heading},
-	"=":      {Token: heading_token, State: heading},
-}
-
-var matcherFunctions = map[byte]func(*int, *[]byte) (TokenGrammar, bool){
-	byte('['): matchNext,
-	byte(']'): matchNext,
-	byte('{'): matchThisOrNext,
-	byte('}'): matchThisOrNext,
-	byte('='): matchMany,
-}
 
 // Matches double characters in sequence (ie. `[[`)
 func matchNext(i *int, chars *[]byte) (TokenGrammar, bool) {
@@ -120,11 +99,49 @@ func canLookBehind(i int) bool {
 }
 
 func getTokenMatch(key []byte, i *int) (TokenGrammar, bool) {
-	rule, ok := grammar[string(key)]
-	if !ok {
+	var rule *TokenGrammar = nil
+
+	if bytes.Equal(key, []byte("[[")) {
+		rule = &TokenGrammar{Token: link_start, State: link}
+	}
+	if bytes.Equal(key, []byte("]]")) {
+		rule = &TokenGrammar{Token: link_end, State: link}
+	}
+	if bytes.Equal(key, []byte("{{")) {
+		rule = &TokenGrammar{Token: template_start, State: template}
+	}
+	if bytes.Equal(key, []byte("}}")) {
+		rule = &TokenGrammar{Token: template_end, State: template}
+	}
+	if bytes.Equal(key, []byte("{")) {
+		rule = &TokenGrammar{Token: table_start, State: table}
+	}
+	if bytes.Equal(key, []byte("}")) {
+		rule = &TokenGrammar{Token: table_end, State: table}
+	}
+	if bytes.Equal(key, []byte("======")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+	if bytes.Equal(key, []byte("=====")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+	if bytes.Equal(key, []byte("====")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+	if bytes.Equal(key, []byte("===")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+	if bytes.Equal(key, []byte("==")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+	if bytes.Equal(key, []byte("=")) {
+		rule = &TokenGrammar{Token: heading_token, State: heading}
+	}
+
+	if rule == nil {
 		return TokenGrammar{}, false
 	}
 
 	*i += len(key) - 1
-	return rule, true
+	return *rule, true
 }

--- a/internal/wikitext/parser.go
+++ b/internal/wikitext/parser.go
@@ -1,9 +1,11 @@
 package wikitext
 
 import (
+	"bytes"
 	"errors"
 	"html"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -17,27 +19,27 @@ func ParseDefinition(raw string, depth int) (string, error) {
 	if len(tokenizer.characters) == 0 {
 		return "", errors.New("No page content.")
 	}
-	definition := ""
+	byteDef := []byte{}
 
 	// While loop, while def length is less than sentence depth, keep batching
 	batchSize := 300
-	for !isDefinitionParsed(&definition, &tokenizer, depth) {
+	for !isDefinitionParsed(&byteDef, &tokenizer, depth) {
 		tokenizer.Tokenize(TokenizerOptions{batchSize})
-		definition = ""
+		byteDef = []byte{}
 
 		// FIXME: we're doing a little extra work by resetting the definition above
 		// and processing tokens over again. Perhaps an unapply last token func?
 		for _, t := range tokenizer.tokens {
 			switch t.Type {
 			case "text":
-				definition += t.Value
-
+				byteDef = append(byteDef, t.Value...)
 			case "link":
-				definition += resolveLink(t.Value)
+				byteDef = append(byteDef, resolveLink(t.Value)...)
 			}
 		}
 	}
 
+	definition := string(byteDef)
 	// resolve depth of definition
 	sentences := strings.SplitAfter(definition, ". ")
 	if depth <= len(sentences) {
@@ -45,7 +47,9 @@ func ParseDefinition(raw string, depth int) (string, error) {
 	}
 	definition = strings.Join(sentences, "")
 
-	// TODO: consider using a strings.Replacer for these replace ops
+	// TODO: consider using a strings.Replacer for these replace ops. The post
+	// and pre tokenization cleaning steps should each only iterate once through
+	// the definition.
 
 	// remove doubled spaces
 	definition = strings.ReplaceAll(definition, "  ", " ")
@@ -59,14 +63,14 @@ func ParseDefinition(raw string, depth int) (string, error) {
 	return definition, nil
 }
 
-func isDefinitionParsed(def *string, t *Tokenizer, depth int) bool {
+func isDefinitionParsed(def *[]byte, t *Tokenizer, depth int) bool {
 	// If we have no tokens, we just started.
 	if len(t.tokens) == 0 {
 		return false
 	}
 
+	sentences := bytes.SplitAfter(*def, []byte{'.', ' '})
 	// resolve depth of definition
-	sentences := strings.SplitAfter(*def, ". ")
 	if depth < len(sentences) || t.tokens[len(t.tokens)-1].Type == "EOF" {
 		return true
 	}
@@ -79,45 +83,48 @@ func isDefinitionParsed(def *string, t *Tokenizer, depth int) bool {
 // If link is in our list of unsupported, ignore it
 // If link type is specified and does not contain display, ignore it
 // If link type is specified but does contain display, keep it
-func resolveLink(link string) string {
+func resolveLink(link []byte) []byte {
 	// Since we're only parsing text from wikis, we don't want to handle link
 	// types that don't include useful display text (ie. files, media)
-	unsupported := []string{"file:", "media:"}
+	unsupported := [][]byte{[]byte("file:"), []byte("media:")}
 
 	for _, u := range unsupported {
-		if strings.Contains(strings.ToLower(link), u) {
-			return ""
+		if bytes.Contains(bytes.ToLower(link), u) {
+			return []byte{}
 		}
 	}
 
-	// link with display text [[name of page|display text]]
-	if strings.Contains(link, "|") {
-		parts := strings.Split(link, "|")
-		hasDisplay := len(parts) == 2
-
-		if hasDisplay {
-			return strings.Join(parts[1:], "")
+	// link with display text (pipe link) -- [[name of page|display text]]
+	if slices.Contains(link, '|') {
+		idx := slices.Index(link, '|')
+		hasDisplayText := len(link) - 1 > idx
+		if hasDisplayText {	
+			return link[idx + 1:]
 		}
-		return ""
+
+		return []byte{}
 	}
 
-	if strings.Contains(link, ":") {
-		return ""
+	if slices.Contains(link, ':') {
+		return []byte{}
 	}
 
 	return link
 }
 
+var newlineReg = regexp.MustCompile(`(\n){3,}`)
+
 // Collapses excessive newlines into double-spaced break.
 func collapseNewlines(s string) string {
-	reg := regexp.MustCompile(`(\n){3,}`)
-	return reg.ReplaceAllString(s, "\n\n")
+	return newlineReg.ReplaceAllString(s, "\n\n")
 }
 
+var indentReg = regexp.MustCompile(`(^|\n)(:){1,6}`)
+
+// TODO indents should be handled by the tokenizer
 func handleIndents(s string) string {
 	// Matches up to 6 levels of indent on first line or any new line
-	reg := regexp.MustCompile(`(^|\n)(:){1,6}`)
-	return reg.ReplaceAllStringFunc(s, func(match string) string {
+	return indentReg.ReplaceAllStringFunc(s, func(match string) string {
 		return strings.ReplaceAll(match, ":", "  ")
 	})
 }

--- a/internal/wikitext/parser_test.go
+++ b/internal/wikitext/parser_test.go
@@ -97,7 +97,8 @@ func TestParseWord(t *testing.T) {
 
 func BenchmarkParsing(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ParseDefinition(sample_wikitext_lg, 1)
-		ParseDefinition(sample_wikitext_sm, 1)
+		for _, page := range benchmark_sample_text {
+			ParseDefinition(page, 3)
+		}
 	}
 }

--- a/internal/wikitext/test_assets.go
+++ b/internal/wikitext/test_assets.go
@@ -2,8 +2,22 @@ package wikitext
 
 import _ "embed"
 
-//go:embed fixtures/test_wikitext_lg.txt
-var sample_wikitext_lg string
+//go:embed fixtures/test_wikitext_lg_1.txt
+var sample_wikitext_lg_1 string
+//go:embed fixtures/test_wikitext_lg_2.txt
+var sample_wikitext_lg_2 string
+//go:embed fixtures/test_wikitext_lg_3.txt
+var sample_wikitext_lg_3 string
+//go:embed fixtures/test_wikitext_lg_4.txt
+var sample_wikitext_lg_4 string
 
 //go:embed fixtures/test_wikitext_sm.txt
 var sample_wikitext_sm string
+
+var benchmark_sample_text = []string{
+	sample_wikitext_sm,
+	sample_wikitext_lg_1,
+	sample_wikitext_lg_2,
+	sample_wikitext_lg_3,
+	sample_wikitext_lg_4,
+}

--- a/internal/wikitext/tokenizer.go
+++ b/internal/wikitext/tokenizer.go
@@ -199,14 +199,35 @@ func (t *Tokenizer) Tokenize(options TokenizerOptions) *Tokenizer {
 func (t *Tokenizer) GetTokenType() TokenGrammar {
 	currChar := t.characters[t.i]
 
-	matcherFunc, ok := matcherFunctions[currChar]
-	if !ok {
-		return TEXT_TOKEN
+	if currChar == '[' {
+		t, isMatch := matchNext(&t.i, &t.characters)
+		if isMatch {
+			return t
+		}
 	}
-
-	r, isMatch := matcherFunc(&t.i, &t.characters)
-	if isMatch {
-		return r
+	if currChar == ']' {
+		t, isMatch := matchNext(&t.i, &t.characters)
+		if isMatch {
+			return t
+		}
+	}
+	if currChar == '{' {
+		t, isMatch := matchThisOrNext(&t.i, &t.characters)
+		if isMatch {
+			return t
+		}
+	}
+	if currChar == '}' {
+		t, isMatch := matchThisOrNext(&t.i, &t.characters)
+		if isMatch {
+			return t
+		}
+	}
+	if currChar == '=' {
+		t, isMatch := matchMany(&t.i, &t.characters)
+		if isMatch {
+			return t
+		}
 	}
 
 	return TEXT_TOKEN

--- a/internal/wikitext/tokenizer.go
+++ b/internal/wikitext/tokenizer.go
@@ -9,15 +9,25 @@ import (
 
 type Token struct {
 	Type  State
-	Value string
+	Value []byte
 }
 
 // Since we only care about text content, tokenized results are
 // represented as a flat collection.
 type TokenCollection []Token
 
+// Used for testing purposes
 func (t *TokenCollection) Stringify() (string, error) {
-	json, err := json.Marshal(t)
+	// byte arrays get serialized to base64 so we convert them to strings first
+	serializableTokens := []map[string]string{}
+	for _, token := range *t {
+		serializableTokens = append(serializableTokens, map[string]string{
+			"Value": string(token.Value),
+			"Type": string(token.Type),
+		})
+	}
+
+	json, err := json.Marshal(serializableTokens)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +59,7 @@ func (s StateStack) len() int {
 type Tokenizer struct {
 	tokens     TokenCollection
 	state      StateStack
-	characters []string
+	characters []byte
 	i          int
 }
 
@@ -60,17 +70,17 @@ type TokenizerOptions struct {
 
 func NewTokenizer(raw string) Tokenizer {
 	cleaned := cleanDocument(raw)
-	characters := strings.Split(cleaned, "")
+	characters := []byte(cleaned)
 
 	return Tokenizer{characters: characters, state: StateStack{unset}}
 }
 
-func (t *Tokenizer) batcher(batch int, size int) []string {
+func (t *Tokenizer) batcher(batch int, size int) []byte {
 	start := (batch - 1) * size
 	end := batch * size
 
 	if start > len(t.characters) {
-		return []string{}
+		return []byte{}
 	}
 
 	if end > len(t.characters) {
@@ -82,7 +92,7 @@ func (t *Tokenizer) batcher(batch int, size int) []string {
 
 // FIXME: this can be cleaned up, let's make it leaner and easier to extend --
 // already started the improvements with the tokentype func, let's keep going
-func (t *Tokenizer) Tokenize(options TokenizerOptions) Tokenizer {
+func (t *Tokenizer) Tokenize(options TokenizerOptions) *Tokenizer {
 	batch := len(t.characters)
 	if options.batchSize != 0 {
 		maybeBatch := t.i + options.batchSize
@@ -93,20 +103,22 @@ func (t *Tokenizer) Tokenize(options TokenizerOptions) Tokenizer {
 
 	for t.i < batch {
 		char := t.characters[t.i]
+
 		tt := t.GetTokenType()
 
 		switch t.state.getState() {
 		case unset:
 			if tt.Token == text_token {
 				t.state = t.state.set(text)
-				t.newToken(char)
+				t.newToken()
+				t.appendToToken(char)
 				break
 			}
 			fallthrough
 		case text:
 			if tt.Token != text_token {
 				t.state = t.state.set(tt.State)
-				t.newToken("")
+				t.newToken()
 				break
 			}
 			if tt.Token == text_token {
@@ -175,13 +187,13 @@ func (t *Tokenizer) Tokenize(options TokenizerOptions) Tokenizer {
 		// End of file
 		if t.i == len(t.characters)-1 {
 			t.state.set(EOF)
-			t.newToken("")
+			t.newToken()
 		}
 
 		t.i++
 	}
 
-	return *t
+	return t
 }
 
 func (t *Tokenizer) GetTokenType() TokenGrammar {
@@ -200,27 +212,28 @@ func (t *Tokenizer) GetTokenType() TokenGrammar {
 	return TEXT_TOKEN
 }
 
-func (t *Tokenizer) newToken(char string) {
-	newTkn := Token{Type: t.state.getState(), Value: char}
+// Initializes a new empty token based on the current state
+func (t *Tokenizer) newToken() {
+	newTkn := Token{Type: t.state.getState(), Value: []byte{}}
 	t.tokens = append(t.tokens, newTkn)
 }
 
-func (t *Tokenizer) appendToToken(char string) {
+func (t *Tokenizer) appendToToken(char byte) {
 	if len(t.tokens) > 0 {
 		currTkn := &t.tokens[len(t.tokens)-1]
-		// potential improvement would be to store this as an array until we finish
-		// the token and then we can close it off by joining.
-		currTkn.Value += char
+		currTkn.Value = append(currTkn.Value, char)
 	}
 }
+
+var urlReg = regexp.MustCompile(`(f|ht)(tp)(s?)(://)(\S*)[.|/]([^\s\]\}]*)`)
 
 // Prepares document for tokenization.
 func cleanDocument(t string) string {
 	s := cleanHtml(t)
-	// strip urls from text (likely came from <ref> tags that got cleaned above
-	urlReg := regexp.MustCompile(`(f|ht)(tp)(s?)(://)(\S*)[.|/]([^\s\]\}]*)`)
+	// strip urls from text (likely from <ref> tags that got cleaned)
 	s = urlReg.ReplaceAllString(s, "")
 
+	// TODO handle bold + italics in tokenizer
 	// wikitext bold
 	s = strings.ReplaceAll(s, "'''", "")
 	// wikitext italics
@@ -229,35 +242,40 @@ func cleanDocument(t string) string {
 	return s
 }
 
+// TODO Look into wrapping this into the main tokenizer or at least wrapping
+// all the cleaning steps into a single iterator. Currently we iterate over
+// the string multiple times when doing replace ops + cleanHtml
 func cleanHtml(s string) string {
-	// Tags whose inner content we don't want to preserve
-	removeHtmlContent := []string{"ref"}
-	chars := strings.Split(s, "")
-	cleanedText := []string{}
+	chars := []byte(s)
+	cleanedText := []byte{}
 
 	tagType := ""
+
+	// Tags whose inner content we don't want to preserve
+	removeHtmlContent := []string{"ref"}
+
 	// when true, write to cleanedText
 	write := true
 	tag := ""
 	tags := []string{} // to track nesting of clean html content tags
 	for i, c := range chars {
-		if c == "<" {
+		if c == '<' {
 			tagType = "open"
 
 			lookAhead := canLookAhead(i, &chars)
-			if lookAhead && chars[i+1] == "/" {
+			if lookAhead && chars[i+1] == '/' {
 				tagType = "close"
 			}
 			write = false
 			continue
 		}
 
-		if c == ">" {
+		if c == '>' {
 			// ignore attributes that may have been captured along with the tag
 			parsedTag := strings.Split(tag, " ")[0]
 
 			// handle self-closingtags
-			if canLookBehind(i, &chars) && chars[i-1] == "/" {
+			if canLookBehind(i) && chars[i-1] == '/' {
 				tagType = "close"
 			}
 
@@ -295,11 +313,11 @@ func cleanHtml(s string) string {
 			cleanedText = append(cleanedText, c)
 		}
 		if tagType != "" {
-			tag += c
+			tag += string(c)
 		}
 	}
 
-	return strings.Join(cleanedText, "")
+	return string(cleanedText)
 }
 
 func pop(s []string) []string {

--- a/internal/wikitext/tokenizer_test.go
+++ b/internal/wikitext/tokenizer_test.go
@@ -28,7 +28,6 @@ func TestTokenizer(t *testing.T) {
 		{"= Description =", `[{"Type":"heading","Value":" Description "},{"Type":"EOF","Value":""}]`},
 		{"==Description==", `[{"Type":"heading","Value":"Description"},{"Type":"EOF","Value":""}]`},
 		{"======= Description =======", `[{"Type":"text","Value":"="},{"Type":"heading","Value":" Description ="},{"Type":"EOF","Value":""}]`}, // not great but this is better than destroying text
-		//{"::Description", `[{"Type":"indent","Value":" Description"},{"Type":"EOF","Value":""}]`},
 	}
 
 	for _, c := range cases {
@@ -77,18 +76,18 @@ func TestTokenBatcher(t *testing.T) {
 		tokenizer := NewTokenizer(testSimpleText)
 		batch := tokenizer.batcher(1, 5)
 		test.IsEqual(t, len(batch), 5, "")
-		test.IsEqual(t, batch[0], "t", "")
-		test.IsEqual(t, batch[4], " ", "")
+		test.BytesEqual(t, batch[0], 't', "")
+		test.BytesEqual(t, batch[4], ' ', "")
 
 		batch = tokenizer.batcher(2, 5)
 		test.IsEqual(t, len(batch), 5, "")
-		test.IsEqual(t, batch[0], "i", "")
-		test.IsEqual(t, batch[4], " ", "")
+		test.BytesEqual(t, batch[0], 'i', "")
+		test.BytesEqual(t, batch[4], ' ', "")
 
 		batch = tokenizer.batcher(3, 5)
 		test.IsEqual(t, len(batch), 4, "")
-		test.IsEqual(t, batch[0], "t", "")
-		test.IsEqual(t, batch[3], "t", "")
+		test.BytesEqual(t, batch[0], 't', "")
+		test.BytesEqual(t, batch[3], 't', "")
 
 		batch = tokenizer.batcher(4, 5)
 		test.IsEqual(t, len(batch), 0, "")
@@ -98,7 +97,7 @@ func TestTokenBatcher(t *testing.T) {
 		tokenizer := NewTokenizer(testSimpleText)
 		batch := tokenizer.Tokenize(TokenizerOptions{5})
 		test.IsEqual(t, batch.tokens[0].Type, text, "")
-		test.IsEqual(t, batch.tokens[0].Value, "this ", "")
+		test.IsEqual(t, string(batch.tokens[0].Value), "this ", "")
 	})
 
 	testWikiText := "[[link]] some text"
@@ -107,31 +106,31 @@ func TestTokenBatcher(t *testing.T) {
 		tokenizer := NewTokenizer(testWikiText)
 		batch1 := tokenizer.Tokenize(TokenizerOptions{5})
 		test.IsEqual(t, batch1.tokens[0].Type, link, "")
-		test.IsEqual(t, batch1.tokens[0].Value, "lin", "")
+		test.IsEqual(t, string(batch1.tokens[0].Value), "lin", "")
 
 		batch2 := tokenizer.Tokenize(TokenizerOptions{5})
 		test.IsEqual(t, batch2.tokens[0].Type, link, "")
-		test.IsEqual(t, batch2.tokens[0].Value, "link", "")
+		test.IsEqual(t, string(batch2.tokens[0].Value), "link", "")
 		test.IsEqual(t, batch2.tokens[1].Type, text, "")
-		test.IsEqual(t, batch2.tokens[1].Value, " s", "")
+		test.IsEqual(t, string(batch2.tokens[1].Value), " s", "")
 
 		// increase batch size (also means we need to adjust our batch no.)
 		batch3 := tokenizer.Tokenize(TokenizerOptions{10})
 		test.IsEqual(t, batch3.tokens[1].Type, text, "")
-		test.IsEqual(t, batch3.tokens[1].Value, " some text", "")
+		test.IsEqual(t, string(batch3.tokens[1].Value), " some text", "")
 	})
 
 	// This test will batch in the middle of the template token
 	testTemplateBatch := "{{a|b}}test"
 	t.Run("Test tokenize wikitext in batches on token boundary", func(t *testing.T) {
 		tokenizer := NewTokenizer(testTemplateBatch)
-		batch1 := tokenizer.Tokenize(TokenizerOptions{6})
+		batch1 := tokenizer.Tokenize(TokenizerOptions{5})
 		test.IsEqual(t, batch1.tokens[0].Type, template, "")
-		test.IsEqual(t, batch1.tokens[0].Value, "a|b", "")
+		test.IsEqual(t, string(batch1.tokens[0].Value), "a|b", "")
 
 		batch2 := tokenizer.Tokenize(TokenizerOptions{6})
 		test.IsEqual(t, batch2.tokens[1].Type, text, "")
-		test.IsEqual(t, batch2.tokens[1].Value, "test", "")
+		test.IsEqual(t, string(batch2.tokens[1].Value), "test", "")
 	})
 }
 func BenchmarkTokenizer(b *testing.B) {

--- a/internal/wikitext/tokenizer_test.go
+++ b/internal/wikitext/tokenizer_test.go
@@ -137,10 +137,9 @@ func TestTokenBatcher(t *testing.T) {
 func BenchmarkTokenizer(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
-		tokenizer := NewTokenizer(sample_wikitext_lg)
-		tokenizer.Tokenize(TokenizerOptions{})
-
-		tokenizer = NewTokenizer(sample_wikitext_sm)
-		tokenizer.Tokenize(TokenizerOptions{})
+		for _, page := range benchmark_sample_text {
+			tokenizer := NewTokenizer(page)
+			tokenizer.Tokenize(TokenizerOptions{})
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	pprof "runtime/pprof"
 
 	"github.com/runik-3/builder/dict"
 	wikibot "github.com/runik-3/builder/wikiBot"
@@ -15,8 +17,19 @@ func main() {
 	name := flag.String("n", "", "The file name of the generated dictionary (extension added automatically).")
 	output := flag.String("o", "", "The output directory where generated dictionary will be written. If not passed in, no file will be generated (preferred behaviour when calling builder as module).")
 	format := flag.String("f", "json", "Format of the output file.")
+	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to file")
 
 	flag.Parse()
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
 	options := dict.GeneratorOptions{
 		Name:         *name,
 		Output:       *output,


### PR DESCRIPTION
Picking the low hanging fruit and finally updating the tokenizer + parser to manipulate byte arrays instead of strings, significantly improving wikitext performance.

M1 Macbook Air Benchmarks

Before 
```
    goos: darwin
    goarch: arm64
    pkg: github.com/runik-3/builder/internal/wikitext
    cpu: Apple M1
    BenchmarkParsing-8            50          13134739 ns/op
    BenchmarkParsing-8            50          13264456 ns/op
    BenchmarkParsing-8            50          13254925 ns/op
    BenchmarkParsing-8            50          13362852 ns/op
    BenchmarkParsing-8            50          13276475 ns/op
    BenchmarkTokenizer-8          50          25813375 ns/op
    BenchmarkTokenizer-8          50          25874488 ns/op
    BenchmarkTokenizer-8          50          26030726 ns/op
    BenchmarkTokenizer-8          50          25953580 ns/op
    BenchmarkTokenizer-8          50          26205046 ns/op
    PASS
    ok      github.com/runik-3/builder/internal/wikitext    10.286s
```

After

```
    goos: darwin
    goarch: arm64
    pkg: github.com/runik-3/builder/internal/wikitext
    cpu: Apple M1
    BenchmarkParsing-8            50           4459576 ns/op
    BenchmarkParsing-8            50           3899183 ns/op
    BenchmarkParsing-8            50           3931703 ns/op
    BenchmarkParsing-8            50           3901440 ns/op
    BenchmarkParsing-8            50           3918766 ns/op
    BenchmarkTokenizer-8          50           4642916 ns/op
    BenchmarkTokenizer-8          50           4658988 ns/op
    BenchmarkTokenizer-8          50           4652071 ns/op
    BenchmarkTokenizer-8          50           4620224 ns/op
    BenchmarkTokenizer-8          50           4638111 ns/op
    PASS
    ok      github.com/runik-3/builder/internal/wikitext    2.390s
```